### PR TITLE
Roady app packages1651518957

### DIFF
--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -92,7 +92,8 @@ if(
         $textAdventureUploader->currentRequest()->getUniqueId(),
         'lastRequest' =>
         $textAdventureUploader->previousRequest()->getUniqueId(),
-        'postRequestId' => $textAdventureUploader->postRequestId(),
+        $textAdventureUploader::POST_REQUEST_ID_INDEX
+        => $textAdventureUploader->postRequestId(),
     ];
 
     echo '<ul class="roady-ul-list">';
@@ -158,25 +159,35 @@ if(
 >
     <label
         class="roady-form-input-label"
-        for="<?php echo $textAdventureUploader::FILE_TO_UPLOAD_INDEX; ?>"
+        for="<?php
+            echo $textAdventureUploader::FILE_TO_UPLOAD_INDEX;
+        ?>"
     >
         Select A Twine Html File To Upload:
     </label>
     <input
-        id="<?php echo $textAdventureUploader::FILE_TO_UPLOAD_INDEX; ?>"
+        id="<?php
+            echo $textAdventureUploader::FILE_TO_UPLOAD_INDEX;
+        ?>"
         class="roady-form-input"
         type="file"
-        name="<?php echo $textAdventureUploader::FILE_TO_UPLOAD_INDEX; ?>"
+        name="<?php
+            echo $textAdventureUploader::FILE_TO_UPLOAD_INDEX;
+        ?>"
     >
     <label
         class="roady-form-input-label"
-        for="replaceExistingGame"
+        for="<?php
+                echo
+                $textAdventureUploader::REPLACE_EXISTING_GAME_INDEX;
+            ?>"
     >
         Replace Existing Game:
     </label>
-    <-- @todo $textAdventureUploader::REPLACE_EXISTING_GAME_INDEX -->
     <input
-        id="replaceExistingGame"
+        id="<?php
+            echo $textAdventureUploader::REPLACE_EXISTING_GAME_INDEX;
+        ?>"
         class="roady-form-input"
         type="checkbox"
         <?php
@@ -185,13 +196,16 @@ if(
             default => '',
         };
         ?>
-        name="replaceExistingGame"
+        name="<?php
+            echo $textAdventureUploader::REPLACE_EXISTING_GAME_INDEX;
+        ?>"
         value="true"
     >
-    <-- @todo $textAdventureUploader::POST_REQUEST_ID_INDEX -->
     <input
         type="hidden"
-        name="postRequestId"
+        name="<?php
+            echo $textAdventureUploader::POST_REQUEST_ID_INDEX;
+        ?>"
         value="<?php
         echo $textAdventureUploader->currentRequest()
                                    ->getUniqueId();

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -110,14 +110,6 @@ if(
         echo $aFileWasNotSelectedMessage;
         $uploadIsPossible = false;
     }
-    if(
-        $uploadIsPossible !== false
-        &&
-        !$textAdventureUploader->fileToUploadIsAnHtmlFile()
-    ) {
-        echo $invalidFileTypeMessage;
-        $uploadIsPossible = false;
-    }
     if (
         $uploadIsPossible
         &&

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -32,19 +32,9 @@ $currentRequest = new Request(
     new Switchable()
 );
 
-try {
-    $lastRequest = $componentCrud->readByNameAndType(
-        $currentRequest->getName(),
-        $currentRequest->getType(),
-        $currentRequest->getLocation(),
-        $currentRequest->getContainer()
-    );
-    $componentCrud->update($lastRequest, $currentRequest);
-} catch (\RuntimeException $errorMessage) {
-    $componentCrud->create($currentRequest);
-}
-
-$textAdventureUploader = new TextAdventureUploader($currentRequest);
+$textAdventureUploader = new TextAdventureUploader(
+    $currentRequest, $componentCrud
+);
 $uploadIsPossible = true;
 $aFileWasNotSelectedMessage = '
     <p class="roady-error-message">
@@ -78,17 +68,26 @@ $theSpecifiedTwineFileWasAlreadyImportedMessage = "
     </div>
 ";
 
+try {
+    $lastRequest = $componentCrud->readByNameAndType(
+        $currentRequest->getName(),
+        $currentRequest->getType(),
+        $currentRequest->getLocation(),
+        $currentRequest->getContainer()
+    );
+    $componentCrud->update($lastRequest, $currentRequest);
+} catch (\RuntimeException $errorMessage) {
+    $componentCrud->create($currentRequest);
+}
 $lastRequestId = (
     isset($lastRequest)
     ? $lastRequest->getUniqueId()
     : ''
 );
-
 $postRequestId = (
-    isset(
-        $currentRequest->getPost()['lastRequestId'])
-        ? $currentRequest->getPost()['lastRequestId']
-        : strval(rand(1000, 70000)
+    isset($currentRequest->getPost()['lastRequestId'])
+    ? $currentRequest->getPost()['lastRequestId']
+    : strval(rand(1000, 70000)
     )
 );
 

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -23,6 +23,7 @@ $componentCrud = new ComponentCrud(
         new Switchable()
     )
 );
+
 $currentRequest = new Request(
     new Storable(
         'LastRequest',

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -114,15 +114,7 @@ if(
     if (
         $uploadIsPossible !== false
         &&
-        boolval(
-            (
-                $textAdventureUploader->currentRequest()
-                                      ->getPost()
-                                      ['replaceExistingGame']
-                ??
-                false
-            )
-        ) !== true
+        $textAdventureUploader->replaceExistingGame() !== true
         &&
         file_exists($textAdventureUploader->pathToUploadFileTo())
     ) {

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -158,22 +158,23 @@ if(
 >
     <label
         class="roady-form-input-label"
-        for="fileToUpload"
+        for="<?php echo $textAdventureUploader::FILE_TO_UPLOAD_INDEX; ?>"
     >
         Select A Twine Html File To Upload:
     </label>
     <input
-        id="fileToUpload"
+        id="<?php echo $textAdventureUploader::FILE_TO_UPLOAD_INDEX; ?>"
         class="roady-form-input"
         type="file"
-        name="fileToUpload"
+        name="<?php echo $textAdventureUploader::FILE_TO_UPLOAD_INDEX; ?>"
     >
     <label
         class="roady-form-input-label"
-        for="fileToUpload"
+        for="replaceExistingGame"
     >
         Replace Existing Game:
     </label>
+    <-- @todo $textAdventureUploader::REPLACE_EXISTING_GAME_INDEX -->
     <input
         id="replaceExistingGame"
         class="roady-form-input"
@@ -187,6 +188,7 @@ if(
         name="replaceExistingGame"
         value="true"
     >
+    <-- @todo $textAdventureUploader::POST_REQUEST_ID_INDEX -->
     <input
         type="hidden"
         name="postRequestId"

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -133,7 +133,8 @@ if(
         }
         echo match(
             move_uploaded_file(
-                $_FILES["fileToUpload"]["tmp_name"],
+                $_FILES["fileToUpload"]["tmp_name"],// @todo $textAdventureUploader->fileToUploadsTemporaryName()
+
                 $textAdventureUploader->pathToUploadFileTo()
             )
         ) {
@@ -141,7 +142,7 @@ if(
                 <p class=\"roady-success-message\">
                     The file ".
                     htmlspecialchars(
-                        basename($_FILES["fileToUpload"]["name"])
+                        basename($textAdventureUploader->fileToUploadsActualName())
                     ) .
                     " has been uploaded.
                 </p>",
@@ -183,15 +184,8 @@ if(
         class="roady-form-input"
         type="checkbox"
         <?php
-        echo match(
-            (
-                $textAdventureUploader->currentRequest()
-                                      ->getPost()['replaceExistingGame']
-                ??
-                ''
-            )
-        ) {
-            'true' => 'checked',
+        echo match($textAdventureUploader->replaceExistingGame()) {
+            true => 'checked',
             default => '',
         };
         ?>
@@ -201,7 +195,10 @@ if(
     <input
         type="hidden"
         name="postRequestId"
-        value="<?php echo $textAdventureUploader->currentRequest()->getUniqueId(); ?>"
+        value="<?php
+        echo $textAdventureUploader->currentRequest()
+                                   ->getUniqueId();
+        ?>"
     >
     <input
         class="roady-form-input"

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -136,15 +136,7 @@ if(
         $uploadIsPossible = false;
     }
     if ($uploadIsPossible) {
-        if(
-            !is_dir(
-                $textAdventureUploader->pathToUploadsDirectory()
-            )
-        ) {
-            mkdir(
-                $textAdventureUploader->pathToUploadsDirectory()
-            );
-        }
+        $textAdventureUploader->upload();
         echo match(
             move_uploaded_file(
                 $textAdventureUploader->fileToUploadsTemporaryName(),

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -83,10 +83,7 @@ if(
                             '--name',
                             'ConfiguredOutput',
                             '--output',
-                            'Test Output',
-                            '--relative-urls',
-                            '/',
-                            'index.php'
+                            strval(file_get_contents($textAdventureUploader->pathToUploadFileTo())),
                         ]
                     )
                 );

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -32,6 +32,16 @@ $currentRequest = new Request(
     new Switchable()
 );
 
+try {
+    $lastRequest = $componentCrud->readByNameAndType(
+        $currentRequest->getName(),
+        $currentRequest->getType(),
+        $currentRequest->getLocation(),
+        $currentRequest->getContainer()
+    );
+} catch (\RuntimeException $errorMessage) {
+    $lastRequest = $currentRequest;
+}
 $textAdventureUploader = new TextAdventureUploader(
     $currentRequest, $componentCrud
 );
@@ -68,22 +78,6 @@ $theSpecifiedTwineFileWasAlreadyImportedMessage = "
     </div>
 ";
 
-try {
-    $lastRequest = $componentCrud->readByNameAndType(
-        $currentRequest->getName(),
-        $currentRequest->getType(),
-        $currentRequest->getLocation(),
-        $currentRequest->getContainer()
-    );
-    $componentCrud->update($lastRequest, $currentRequest);
-} catch (\RuntimeException $errorMessage) {
-    $componentCrud->create($currentRequest);
-}
-$lastRequestId = (
-    isset($lastRequest)
-    ? $lastRequest->getUniqueId()
-    : ''
-);
 $postRequestId = (
     isset($currentRequest->getPost()['lastRequestId'])
     ? $currentRequest->getPost()['lastRequestId']
@@ -92,13 +86,13 @@ $postRequestId = (
 );
 
 if(
-    $lastRequestId
+    $lastRequest->getUniqueId()
     ===
     $postRequestId
 ) {
     $vars = [
         'currentRequstId' => $currentRequest->getUniqueId(),
-        'lastRequest' => $lastRequestId,
+        'lastRequest' => $lastRequest->getUniqueId(),
         'postRequestId' => $postRequestId,
     ];
 

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -66,6 +66,20 @@ $textAdventureUploader = new TextAdventureUploader(
     )
 );
 
+$fileUploadedSuccessfullyMessage = "
+    <p class=\"roady-success-message\">
+        The file ".
+        htmlspecialchars(
+            basename($textAdventureUploader->fileToUploadsActualName())
+        ) .
+    " has been uploaded.
+    </p>";
+
+$failedToUploadFileMessage = "
+    <p class=\"roady-error-message\">
+        Sorry, there was an error uploading your file.
+    </p>";
+
 $uploadIsPossible = true;
 
 if(
@@ -133,23 +147,12 @@ if(
         }
         echo match(
             move_uploaded_file(
-                $_FILES["fileToUpload"]["tmp_name"],// @todo $textAdventureUploader->fileToUploadsTemporaryName()
-
+                $textAdventureUploader->fileToUploadsTemporaryName(),
                 $textAdventureUploader->pathToUploadFileTo()
             )
         ) {
-            true => "
-                <p class=\"roady-success-message\">
-                    The file ".
-                    htmlspecialchars(
-                        basename($textAdventureUploader->fileToUploadsActualName())
-                    ) .
-                    " has been uploaded.
-                </p>",
-            default => "
-                <p class=\"roady-error-message\">
-                    Sorry, there was an error uploading your file.
-                </p>",
+            true => $fileUploadedSuccessfullyMessage,
+            default => $failedToUploadFileMessage,
         };
     }
 }

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -119,24 +119,10 @@ if(
         $uploadIsPossible = false;
     }
     if (
-        $uploadIsPossible !== false
+        $uploadIsPossible
         &&
-        $textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize()
+        $textAdventureUploader->uploadIsPossible()
     ) {
-        echo $fileIsToLargeMessage;
-        $uploadIsPossible = false;
-    }
-    if (
-        $uploadIsPossible !== false
-        &&
-        $textAdventureUploader->replaceExistingGame() !== true
-        &&
-        file_exists($textAdventureUploader->pathToUploadFileTo())
-    ) {
-        echo $theSpecifiedTwineFileWasAlreadyImportedMessage;
-        $uploadIsPossible = false;
-    }
-    if ($uploadIsPossible) {
         $textAdventureUploader->upload();
         echo match(
             move_uploaded_file(

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -70,7 +70,7 @@ $fileUploadedSuccessfullyMessage = "
     <p class=\"roady-success-message\">
         The file ".
         htmlspecialchars(
-            basename($textAdventureUploader->fileToUploadsActualName())
+            basename($textAdventureUploader->nameOfFileToUpload())
         ) .
     " has been uploaded.
     </p>";

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -71,6 +71,13 @@ if(
         };
         if($uploadWasSuccessful) {
             try {
+                $componentName = strval(
+                    preg_replace(
+                        "/[^A-Za-z0-9 ]/",
+                        '',
+                        str_replace('.html', '', $textAdventureUploader->nameOfFileToUpload())
+                    )
+                );
                 echo '<div class="roady-generic-container">';
                 echo '<pre class="roady-multi-line-code-container">';
                 echo '<code class="roady-multi-line-code">';
@@ -79,11 +86,15 @@ if(
                     $configureAppOutput->prepareArguments(
                         [
                             '--for-app',
-                            'TryConfiguringAppOutputFromWithinAnApp' . strval(rand(10000, 42000000)),
+                            $componentName,
                             '--name',
-                            'ConfiguredOutput',
+                            $componentName,
                             '--output',
-                            strval(file_get_contents($textAdventureUploader->pathToUploadFileTo())),
+                            strval(
+                                file_get_contents(
+                                    $textAdventureUploader->pathToUploadFileTo()
+                                )
+                            ),
                         ]
                     )
                 );

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -67,28 +67,18 @@ $textAdventureUploader = new TextAdventureUploader(
 );
 
 $uploadIsPossible = true;
-$postRequestId = (
-    isset(
-        $textAdventureUploader->currentRequest()
-                              ->getPost()['postRequestId']
-    )
-    ? $textAdventureUploader->currentRequest()
-                            ->getPost()['postRequestId']
-    : strval(rand(1000, 70000)
-    )
-);
 
 if(
     $textAdventureUploader->previousRequest()->getUniqueId()
     ===
-    $postRequestId
+    $textAdventureUploader->postRequestId()
 ) {
     $vars = [
         'currentRequstId' =>
         $textAdventureUploader->currentRequest()->getUniqueId(),
         'lastRequest' =>
         $textAdventureUploader->previousRequest()->getUniqueId(),
-        'postRequestId' => $postRequestId,
+        'postRequestId' => $textAdventureUploader->postRequestId(),
     ];
 
     echo '<ul class="roady-ul-list">';

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -7,38 +7,6 @@ use roady\classes\primary\Switchable;
 use roady\classes\component\Crud\ComponentCrud;
 use roady\classes\component\Driver\Storage\FileSystem\JsonStorageDriver;
 
-$aFileWasNotSelectedMessage = '
-    <p class="roady-error-message">
-        A Twine html file was not selected.
-        Please select a Twine html file to upload!
-    </p>
-';
-$invalidFileTypeMessage = '
-    <p class="roady-error-message">
-        Only Twine html files can be uploaded!
-        Please select a Twine html file to upload
-    </p>
-';
-$fileIsToLargeMessage = '
-    <p class="roady-error-message">
-        The file is too large!
-    </p>
-';
-
-$theSpecifiedTwineFileWasAlreadyImportedMessage = "
-    <div class=\"roady-error-message\">
-        <p>
-            A Twine file with the same name was already
-            uploaded.
-        </p>
-        <p>
-            Please upload a Twine file with a unique name,
-            or check the <span>Replace Existing App</span>
-            check box below.
-        </p>
-    </div>
-";
-
 $textAdventureUploader = new TextAdventureUploader(
     new Request(
         new Storable(
@@ -79,40 +47,12 @@ $failedToUploadFileMessage = "
     <p class=\"roady-error-message\">
         Sorry, there was an error uploading your file.
     </p>";
-
-$uploadIsPossible = true;
-
 if(
     $textAdventureUploader->previousRequest()->getUniqueId()
     ===
     $textAdventureUploader->postRequestId()
 ) {
-    $vars = [
-        'currentRequstId' =>
-        $textAdventureUploader->currentRequest()->getUniqueId(),
-        'lastRequest' =>
-        $textAdventureUploader->previousRequest()->getUniqueId(),
-        $textAdventureUploader::POST_REQUEST_ID_INDEX
-        => $textAdventureUploader->postRequestId(),
-    ];
-
-    echo '<ul class="roady-ul-list">';
-    foreach($vars as $varKey => $varValue) {
-        echo '<li>' . $varKey . '</li>';
-        echo '<li>' . strval($varValue) . '</li>';
-    }
-    echo '</ul>';
-    if(
-        $textAdventureUploader->nameOfFileToUpload()
-        ===
-        TextAdventureUploader::NO_FILE_SELECTED
-    ) {
-        echo $aFileWasNotSelectedMessage;
-        $uploadIsPossible = false;
-    }
     if (
-        $uploadIsPossible
-        &&
         $textAdventureUploader->uploadIsPossible()
     ) {
         $textAdventureUploader->upload();

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -10,15 +10,16 @@ use rig\classes\command\ConfigureAppOutput;
 use rig\classes\ui\CommandLineUI;
 
 $configureAppOutput = new ConfigureAppOutput();
-$textAdventureUploader = new TextAdventureUploader(
-    new Request(
-        new Storable(
-            'LastRequest',
-            'TextAdventureImporter',
-            'UploadRequests'
-        ),
-        new Switchable()
+$currentRequest = new Request(
+    new Storable(
+        'LastRequest',
+        'TextAdventureImporter',
+        'UploadRequests'
     ),
+    new Switchable()
+);
+$textAdventureUploader = new TextAdventureUploader(
+    $currentRequest,
     new ComponentCrud(
         new Storable(
             'ComponentCrud',
@@ -101,8 +102,39 @@ if(
                 echo '</code>';
                 echo '</pre>';
                 echo '</div>';
+                $pathToAppsComponentsPhp = strval(
+                    str_replace(
+                        'TextAdventureImporter' .
+                        DIRECTORY_SEPARATOR .
+                        'DynamicOutput',
+                        $componentName .
+                        DIRECTORY_SEPARATOR .
+                        'Components.php',
+                        strval(realpath(__DIR__))
+                    )
+                );
+                $host = parse_url(
+                    $currentRequest->getUrl(),
+                    PHP_URL_HOST
+                );
+                $port =  parse_url(
+                    $currentRequest->getUrl(),
+                    PHP_URL_PORT
+                );
+                $rootUrl = 'https://' . $host . $port;
+                var_dump($rootUrl);
+                try {
+                    exec(
+                        PHP_BINARY .
+                        ' ' .
+                        escapeshellarg($pathToAppsComponentsPhp) .
+                        " '" . $rootUrl . "'"
+                    );
+                } catch (\RuntimeException $error) {
+                    echo '<p class="roady-error-message">Failed to build new App</p>';
+                }
             } catch (\RuntimeException $error) {
-                echo '<p class="roady-error-message">An error occurred, ConfiguredOutput failed</p>';
+                echo '<p class="roady-error-message">An error occurred, ConfigureAppOutput failed</p>';
                 echo '<p class="roady-error-message">Error: ' . $error->getMessage() . '</p>';
             }
         }

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -6,7 +6,10 @@ use roady\classes\primary\Storable;
 use roady\classes\primary\Switchable;
 use roady\classes\component\Crud\ComponentCrud;
 use roady\classes\component\Driver\Storage\FileSystem\JsonStorageDriver;
+use rig\classes\command\ConfigureAppOutput;
+use rig\classes\ui\CommandLineUI;
 
+$configureAppOutput = new ConfigureAppOutput();
 $textAdventureUploader = new TextAdventureUploader(
     new Request(
         new Storable(
@@ -56,19 +59,54 @@ if(
         $textAdventureUploader->uploadIsPossible()
     ) {
         $textAdventureUploader->upload();
+        $uploadWasSuccessful = move_uploaded_file(
+            $textAdventureUploader->fileToUploadsTemporaryName(),
+            $textAdventureUploader->pathToUploadFileTo()
+        );
         echo match(
-            move_uploaded_file(
-                $textAdventureUploader->fileToUploadsTemporaryName(),
-                $textAdventureUploader->pathToUploadFileTo()
-            )
+           $uploadWasSuccessful
         ) {
             true => $fileUploadedSuccessfullyMessage,
             default => $failedToUploadFileMessage,
         };
+        if($uploadWasSuccessful) {
+            try {
+                echo '<div class="roady-generic-container">';
+                echo '<pre class="roady-multi-line-code-container">';
+                echo '<code class="roady-multi-line-code">';
+                $configureAppOutput->run(
+                    new CommandLineUI(),
+                    $configureAppOutput->prepareArguments(
+                        [
+                            '--for-app',
+                            'TryConfiguringAppOutputFromWithinAnApp' . strval(rand(10000, 42000000)),
+                            '--name',
+                            'ConfiguredOutput',
+                            '--output',
+                            'Test Output',
+                            '--relative-urls',
+                            '/',
+                            'index.php'
+                        ]
+                    )
+                );
+                echo '</code>';
+                echo '</pre>';
+                echo '</div>';
+            } catch (\RuntimeException $error) {
+                echo '<p class="roady-error-message">An error occurred, ConfiguredOutput failed</p>';
+                echo '<p class="roady-error-message">Error: ' . $error->getMessage() . '</p>';
+            }
+        }
     }
 }
 ?>
 
+<?php
+
+
+
+?>
 <form
     class="roady-form"
     action="index.php?request=TextAdventureImporter"

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -3,6 +3,8 @@
 namespace Apps\TextAdventureImporter\resources\classes\utility;
 
 use roady\classes\component\Web\Routing\Request;
+use roady\classes\component\Crud\ComponentCrud;
+use roady\classes\component\Driver\Storage\FileSystem\JsonStorageDriver;
 use roady\classes\primary\Storable;
 use roady\classes\primary\Switchable;
 
@@ -26,7 +28,8 @@ class TextAdventureUploader {
     public const FILENAME_INDEX = 'name';
 
     public function __construct(
-        private Request $currentRequest
+        private Request $currentRequest,
+        private ComponentCrud $componentCrud
     ) {}
 
     public function pathToUploadsDirectory(): string
@@ -90,6 +93,12 @@ class TextAdventureUploader {
             $_FILES["fileToUpload"]["size"] ?? 5000000
         ) > 5000000;
 
+    }
+
+
+    public function componentCrud(): ComponentCrud
+    {
+        return $this->componentCrud;
     }
 }
 

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -114,7 +114,7 @@ class TextAdventureUploader {
     public function fileToUploadSizeExceedsAllowedFileSize(): bool
     {
         return (
-            $_FILES["fileToUpload"]["size"] ?? 5000000
+            $_FILES[self::FILE_TO_UPLOAD_INDEX]["size"] ?? 5000000
         ) > 5000000;
 
     }
@@ -144,14 +144,9 @@ class TextAdventureUploader {
         );
     }
 
-    public function fileToUploadsActualName(): string
-    {
-        return ($_FILES["fileToUpload"]["name"] ?? '');
-    }
-
     public function fileToUploadsTemporaryName(): string
     {
-        return ($_FILES["fileToUpload"]["tmp_name"] ?? '');
+        return ($_FILES[self::FILE_TO_UPLOAD_INDEX]["tmp_name"] ?? '');
     }
 
     public function upload(): bool

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -25,7 +25,13 @@ class TextAdventureUploader {
 
     public const FILE_TO_UPLOAD_INDEX = 'fileToUpload';
 
+    public const POST_REQUEST_ID_INDEX = 'postRequestId';
+
+    public const REPLACE_EXISTING_GAME_INDEX = 'replaceExistingGame';
+
     public const FILENAME_INDEX = 'name';
+
+    public const TEMPORARY_FILENAME_INDEX = 'tmp_name';
 
     private Request $previousRequest;
 
@@ -85,10 +91,21 @@ class TextAdventureUploader {
     public function nameOfFileToUpload(): string
     {
         return match(
-            !empty($_FILES[self::FILE_TO_UPLOAD_INDEX][self::FILENAME_INDEX] ?? '')
+            !empty(
+                (
+                    $_FILES
+                    [self::FILE_TO_UPLOAD_INDEX]
+                    [self::FILENAME_INDEX]
+                    ??
+                    ''
+                )
+            )
         )
         {
-            true => $_FILES[self::FILE_TO_UPLOAD_INDEX][self::FILENAME_INDEX],
+            true =>
+                $_FILES
+                [self::FILE_TO_UPLOAD_INDEX]
+                [self::FILENAME_INDEX],
             default => self::NO_FILE_SELECTED
         };
     }
@@ -113,6 +130,7 @@ class TextAdventureUploader {
 
     public function fileToUploadSizeExceedsAllowedFileSize(): bool
     {
+        // @todo Refactor to more accurately check file size
         return (
             $_FILES[self::FILE_TO_UPLOAD_INDEX]["size"] ?? 5000000
         ) > 5000000;
@@ -127,7 +145,8 @@ class TextAdventureUploader {
     public function postRequestId(): string
     {
         return (
-            $this->currentRequest()->getPost()['postRequestId']
+            $this->currentRequest()
+                 ->getPost()[self::POST_REQUEST_ID_INDEX]
             ??
             self::NO_FILE_SELECTED
         );
@@ -138,7 +157,7 @@ class TextAdventureUploader {
         return (
             (
                 $this->currentRequest()
-                     ->getPost()['replaceExistingGame']
+                     ->getPost()[self::REPLACE_EXISTING_GAME_INDEX]
                 ??
                 ''
             )
@@ -149,7 +168,11 @@ class TextAdventureUploader {
 
     public function fileToUploadsTemporaryName(): string
     {
-        return ($_FILES[self::FILE_TO_UPLOAD_INDEX]["tmp_name"] ?? self::NO_FILE_SELECTED);
+        return (
+            $_FILES[self::FILE_TO_UPLOAD_INDEX]["tmp_name"]
+            ??
+            self::NO_FILE_SELECTED
+        );
     }
 
     public function upload(): bool

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -119,7 +119,6 @@ class TextAdventureUploader {
 
     }
 
-
     public function componentCrud(): ComponentCrud
     {
         return $this->componentCrud;
@@ -127,7 +126,11 @@ class TextAdventureUploader {
 
     public function postRequestId(): string
     {
-        return ($this->currentRequest()->getPost()['postRequestId'] ?? '');
+        return (
+            $this->currentRequest()->getPost()['postRequestId']
+            ??
+            self::NO_FILE_SELECTED
+        );
     }
 
     public function replaceExistingGame(): bool
@@ -146,7 +149,7 @@ class TextAdventureUploader {
 
     public function fileToUploadsTemporaryName(): string
     {
-        return ($_FILES[self::FILE_TO_UPLOAD_INDEX]["tmp_name"] ?? '');
+        return ($_FILES[self::FILE_TO_UPLOAD_INDEX]["tmp_name"] ?? self::NO_FILE_SELECTED);
     }
 
     public function upload(): bool

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -141,5 +141,11 @@ class TextAdventureUploader {
             'true'
         );
     }
+
+    public function fileToUploadsActualName(): string
+    {
+        return ($_FILES["fileToUpload"]["name"] ?? '');
+    }
+
 }
 

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -153,5 +153,13 @@ class TextAdventureUploader {
     {
         return ($_FILES["fileToUpload"]["tmp_name"] ?? '');
     }
+
+    public function upload(): bool
+    {
+        if(!is_dir($this->pathToUploadsDirectory())) {
+            mkdir($this->pathToUploadsDirectory());
+        }
+        return false;
+    }
 }
 

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -30,7 +30,19 @@ class TextAdventureUploader {
     public function __construct(
         private Request $currentRequest,
         private ComponentCrud $componentCrud
-    ) {}
+    ) {
+        try {
+            $previousRequest = $componentCrud->readByNameAndType(
+                $currentRequest->getName(),
+                $currentRequest->getType(),
+                $currentRequest->getLocation(),
+                $currentRequest->getContainer()
+            );
+            $componentCrud->update($previousRequest, $currentRequest);
+        } catch (\RuntimeException $errorMessage) {
+            $componentCrud->create($currentRequest);
+        }
+    }
 
     public function pathToUploadsDirectory(): string
     {

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -95,6 +95,8 @@ class TextAdventureUploader {
 
     public function fileToUploadIsAnHtmlFile(): bool
     {
+        // @todo Refactor to more securely verify file is an html file
+        // @see https://www.php.net/manual/en/features.file-upload.php
         return strtolower(
             pathinfo(
                 $this->nameOfFileToUpload(),
@@ -147,5 +149,9 @@ class TextAdventureUploader {
         return ($_FILES["fileToUpload"]["name"] ?? '');
     }
 
+    public function fileToUploadsTemporaryName(): string
+    {
+        return ($_FILES["fileToUpload"]["tmp_name"] ?? '');
+    }
 }
 

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -27,11 +27,14 @@ class TextAdventureUploader {
 
     public const FILENAME_INDEX = 'name';
 
+    private Request $previousRequest;
+
     public function __construct(
         private Request $currentRequest,
         private ComponentCrud $componentCrud
     ) {
         try {
+            /** @var Request $previousRequest */
             $previousRequest = $componentCrud->readByNameAndType(
                 $currentRequest->getName(),
                 $currentRequest->getType(),
@@ -39,9 +42,16 @@ class TextAdventureUploader {
                 $currentRequest->getContainer()
             );
             $componentCrud->update($previousRequest, $currentRequest);
+            $this->previousRequest = $previousRequest;
         } catch (\RuntimeException $errorMessage) {
             $componentCrud->create($currentRequest);
+            $this->previousRequest = $currentRequest;
         }
+    }
+
+    public function previousRequest(): Request
+    {
+        return $this->previousRequest;
     }
 
     public function pathToUploadsDirectory(): string

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -127,5 +127,19 @@ class TextAdventureUploader {
     {
         return ($this->currentRequest()->getPost()['postRequestId'] ?? '');
     }
+
+    public function replaceExistingGame(): bool
+    {
+        return (
+            (
+                $this->currentRequest()
+                     ->getPost()['replaceExistingGame']
+                ??
+                ''
+            )
+            ===
+            'true'
+        );
+    }
 }
 

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -25,6 +25,8 @@ class TextAdventureUploader {
 
     public const FILE_TO_UPLOAD_INDEX = 'fileToUpload';
 
+    public const FILE_TO_UPLOAD_SIZE_INDEX = 'size';
+
     public const POST_REQUEST_ID_INDEX = 'postRequestId';
 
     public const REPLACE_EXISTING_GAME_INDEX = 'replaceExistingGame';
@@ -132,7 +134,7 @@ class TextAdventureUploader {
     {
         // @todo Refactor to more accurately check file size
         return (
-            $_FILES[self::FILE_TO_UPLOAD_INDEX]["size"] ?? 5000000
+            $_FILES[self::FILE_TO_UPLOAD_INDEX][TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX] ?? 5000000
         ) > 5000000;
 
     }

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -159,5 +159,33 @@ class TextAdventureUploader {
         }
         return false;
     }
+
+
+    private function safeToReplaceExistingGame(): bool
+    {
+        return match(
+            file_exists($this->pathToUploadFileTo())
+        ) {
+            /**
+             * true: There is an existing game, so return
+             * replaceExistingGame(), whose value
+             * will reflect whether or not the Request
+             * indicated the existing game should
+             * be replaced.
+             */
+            true => $this->replaceExistingGame(),
+            /**
+             * default: There is not an existing game, so a
+             * replacement would not occur, i.e., it is safe
+             * to proceed with upload.
+             */
+            default => true,
+        };
+    }
+
+    public function uploadIsPossible(): bool
+    {
+        return $this->safeToReplaceExistingGame();
+    }
 }
 

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -122,5 +122,10 @@ class TextAdventureUploader {
     {
         return $this->componentCrud;
     }
+
+    public function postRequestId(): string
+    {
+        return ($this->currentRequest()->getPost()['postRequestId'] ?? '');
+    }
 }
 

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -208,7 +208,10 @@ class TextAdventureUploader {
 
     public function uploadIsPossible(): bool
     {
-        return $this->safeToReplaceExistingGame();
+        return
+            !$this->fileToUploadSizeExceedsAllowedFileSize()
+            &&
+            $this->safeToReplaceExistingGame();
     }
 }
 

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -211,6 +211,8 @@ class TextAdventureUploader {
     public function uploadIsPossible(): bool
     {
         return
+            $this->fileToUploadIsAnHtmlFile()
+            &&
             !$this->fileToUploadSizeExceedsAllowedFileSize()
             &&
             $this->safeToReplaceExistingGame();

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -468,7 +468,46 @@ class TextAdventureUploaderTest extends TestCase
             Request::class . '\'s $_POST data if it is defined.'
         );
     }
+
+    public function testReplaceExistingGameReturnsFalseIfValueSetInSpecifiedRequestsPOSTDataForReplaceExistingGameIsNotSetToTheString_true(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $this->assertFalse(
+            $textAdventureUploader->replaceExistingGame(),
+            TextAdventureUploader::class .
+            '->replaceExistingGame() must return false ' .
+            'if the replaceExistingGame value set in the specified ' .
+            Request::class . '\'s $_POST data is not assigned the ' .
+            'string `true`.'
+        );
+    }
+
+    public function testReplaceExistingGameReturnsTrueIfValueSetInSpecifiedRequestsPOSTDataForReplaceExistingGameIsSetToTheString_true(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $request->import(
+            [
+                'post' => [
+                    'replaceExistingGame' => 'true'
+                ]
+            ]
+        );
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $this->assertTrue(
+            $textAdventureUploader->replaceExistingGame(),
+            TextAdventureUploader::class .
+            '->replaceExistingGame() must return true ' .
+            'if the replaceExistingGame value set in the specified ' .
+            Request::class . '\'s $_POST data is assigned the ' .
+            'string `true`.'
+        );
+    }
 }
-/**
- *
- */
+

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -522,11 +522,11 @@ class TextAdventureUploaderTest extends TestCase
             TextAdventureUploader::class .
             '->fileToUploadsActualName() must return an ' .
             'empty string if $_FILES["fileToUpload"]["name"] is ' .
-            'not set'
+            'not set.'
         );
     }
 
-    public function testFileToUploadsActualNameReturnsValueAssignedTo_fileToUpload_name_IsSetIn_FILES(): void
+    public function testFileToUploadsActualNameReturnsValueAssignedTo_fileToUpload_name_IfItIsSetIn_FILES(): void
     {
         $request = $this->mockCurrentRequest();
         $_FILES["fileToUpload"]["name"] = $request->getUniqueId();
@@ -540,8 +540,52 @@ class TextAdventureUploaderTest extends TestCase
             TextAdventureUploader::class .
             '->fileToUploadsActualName() must return an ' .
             'empty string if $_FILES["fileToUpload"]["name"] is ' .
-            'not set'
+            'not set.'
         );
     }
+
+    public function testFileToUploadsTemporaryNameReturnsAnEmptyStringIf_fileToUpload__tmp_name_IsNotSetIn_FILES(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $this->assertEmpty(
+            $textAdventureUploader->fileToUploadsTemporaryName(),
+            TextAdventureUploader::class .
+            '->fileToUploadsTemporaryName() must return an ' .
+            'empty string if $_FILES["fileToUpload"]["tmp_name"] ' .
+            'is not set.'
+        );
+    }
+
+    public function testFileToUploadsTemporaryNameReturnsValueAssignedTo_fileToUpload__tmp_name_IfItIsSetIn_FILES(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $_FILES["fileToUpload"]["tmp_name"] = $request->getUniqueId();
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $this->assertEquals(
+            $request->getUniqueId(),
+            $textAdventureUploader->fileToUploadsTemporaryName(),
+            TextAdventureUploader::class .
+            '->fileToUploadsTemporaryName() must return an ' .
+            'empty string if $_FILES["fileToUpload"]["name"] is ' .
+            'not set.'
+        );
+    }
+
+    /**
+     *
+    public function testUploadIsPossibleReturnsFalseIf(): void
+    {
+    }
+        $textAdventureUploader->replaceExistingGame() !== true
+        &&
+        file_exists($textAdventureUploader->pathToUploadFileTo())
+     */
 }
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -684,5 +684,33 @@ class TextAdventureUploaderTest extends TestCase
         unlink($pathToTestFile);
         rmdir($textAdventureUploader->pathToUploadsDirectory());
     }
+
+    public function testUploadIsPossibleReturnsFalseIfFileToUploadSizeExceedsAllowedFileSizeReturnsTrue(): void
+    {
+        $_FILES["fileToUpload"]["size"] = 5000001;
+        $textAdventureUploader = new TextAdventureUploader(
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
+        );
+        if(
+            $textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize()
+        ) {
+            $this->assertFalse(
+                $textAdventureUploader->uploadIsPossible(),
+                TextAdventureUploader::class .
+                '->uploadIsPossible() must ' .
+                'return false if ' .
+                TextAdventureUploader::class .
+                '->fileToUploadSizeExceedsAllowedFileSize() ' .
+                'returns true'
+            );
+        }
+    }
 }
+/**
+    *
+        $uploadIsPossible !== false
+        &&
+        $textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize()
+ */
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -26,7 +26,7 @@ class TextAdventureUploaderTest extends TestCase
 
     public function tearDown(): void
     {
-        unset($_FILES["fileToUpload"]["name"]);
+        unset($_FILES["fileToUpload"]);
         foreach(
             $this->mockComponentCrud()
                  ->readAll(
@@ -510,40 +510,6 @@ class TextAdventureUploaderTest extends TestCase
         );
     }
 
-    public function testFileToUploadsActualNameReturnsAnEmptyStringIf_fileToUpload_name_IsNotSetIn_FILES(): void
-    {
-        $request = $this->mockCurrentRequest();
-        $textAdventureUploader = new TextAdventureUploader(
-            $request,
-            $this->mockComponentCrud()
-        );
-        $this->assertEmpty(
-            $textAdventureUploader->fileToUploadsActualName(),
-            TextAdventureUploader::class .
-            '->fileToUploadsActualName() must return an ' .
-            'empty string if $_FILES["fileToUpload"]["name"] is ' .
-            'not set.'
-        );
-    }
-
-    public function testFileToUploadsActualNameReturnsValueAssignedTo_fileToUpload_name_IfItIsSetIn_FILES(): void
-    {
-        $request = $this->mockCurrentRequest();
-        $_FILES["fileToUpload"]["name"] = $request->getUniqueId();
-        $textAdventureUploader = new TextAdventureUploader(
-            $request,
-            $this->mockComponentCrud()
-        );
-        $this->assertEquals(
-            $request->getUniqueId(),
-            $textAdventureUploader->fileToUploadsActualName(),
-            TextAdventureUploader::class .
-            '->fileToUploadsActualName() must return an ' .
-            'empty string if $_FILES["fileToUpload"]["name"] is ' .
-            'not set.'
-        );
-    }
-
     public function testFileToUploadsTemporaryNameReturnsAnEmptyStringIf_fileToUpload__tmp_name_IsNotSetIn_FILES(): void
     {
         $request = $this->mockCurrentRequest();
@@ -593,18 +559,23 @@ class TextAdventureUploaderTest extends TestCase
         );
         rmdir($textAdventureUploader->pathToUploadsDirectory());
     }
-}
 
-/**
-
-    public function testUploadIsPossibleReturnsFalseIfAFileWithTheSameNameAsTheFileToUploadWasAlreadyUploaded(): void
+    public function testUploadIsPossibleReturnsFalseIfAFileWithWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUpload(): void
     {
         $request = $this->mockCurrentRequest();
         $textAdventureUploader = new TextAdventureUploader(
             $request,
             $this->mockComponentCrud()
         );
+        $this->assertEquals(
+            $textAdventureUploader->nameOfFileToUpload(),
+            $textAdventureUploader->nameOfFileToUpload()
+        );
     }
+}
+
+/**
+
     $textAdventureUploader->replaceExistingGame() !== true
     &&
     file_exists($textAdventureUploader->pathToUploadFileTo())

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -209,13 +209,15 @@ class TextAdventureUploaderTest extends TestCase
 
     public function testFileToUploadIsAnHtmlFileReturnsTrueIfFileSelcetedForUploadHasTheExtension_html(): void
     {
+        $request = $this->mockCurrentRequest();
         $textAdventureUploader = new TextAdventureUploader(
-            $this->mockCurrentRequest(),
+            $request,
             $this->mockComponentCrud()
         );
         $_FILES
             [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
-            [TextAdventureUploader::FILENAME_INDEX] = 'foo.html';
+            [TextAdventureUploader::FILENAME_INDEX]
+            = $request->getUniqueId() . '.html';
         $this->assertTrue(
             $textAdventureUploader->fileToUploadIsAnHtmlFile(),
             TextAdventureUploader::class .
@@ -620,6 +622,11 @@ class TextAdventureUploaderTest extends TestCase
     public function testUploadIsPossibleReturnsFalseIfAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUploadAndReplaceExistingGameReturnsFalse(): void
     {
         $request = $this->mockCurrentRequest();
+        $testFileName = $request->getUniqueId() . '.html';
+        $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILENAME_INDEX]
+            = $testFileName;
         $textAdventureUploader = new TextAdventureUploader(
             $request,
             $this->mockComponentCrud()
@@ -627,7 +634,7 @@ class TextAdventureUploaderTest extends TestCase
         $pathToTestFile =
             $textAdventureUploader->pathToUploadsDirectory() .
             DIRECTORY_SEPARATOR .
-            $request->getUniqueId();
+            $testFileName;
         if(
             !is_dir($textAdventureUploader->pathToUploadsDirectory())
         ) {
@@ -637,10 +644,6 @@ class TextAdventureUploaderTest extends TestCase
             $pathToTestFile,
             $request->getName()
         );
-        $_FILES
-            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
-            [TextAdventureUploader::FILENAME_INDEX]
-            = $request->getUniqueId();
         if(!$textAdventureUploader->replaceExistingGame()) {
             $this->assertFalse(
                 $textAdventureUploader->uploadIsPossible(),
@@ -659,6 +662,11 @@ class TextAdventureUploaderTest extends TestCase
     public function testUploadIsPossibleReturnsTrueIfAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUploadAndReplaceExistingGameReturnsTrue(): void
     {
         $request = $this->mockCurrentRequest();
+        $testFileName = $request->getUniqueId() . '.html';
+        $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILENAME_INDEX]
+            = $testFileName;
         $request->import(
             [
                 'post' => [
@@ -674,7 +682,7 @@ class TextAdventureUploaderTest extends TestCase
         $pathToTestFile =
             $textAdventureUploader->pathToUploadsDirectory() .
             DIRECTORY_SEPARATOR .
-            $request->getUniqueId();
+            $testFileName;
         if(
             !is_dir($textAdventureUploader->pathToUploadsDirectory())
         ) {
@@ -684,10 +692,6 @@ class TextAdventureUploaderTest extends TestCase
             $pathToTestFile,
             $request->getName()
         );
-        $_FILES
-            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
-            [TextAdventureUploader::FILENAME_INDEX]
-            = $request->getUniqueId();
         if($textAdventureUploader->replaceExistingGame()) {
             $this->assertTrue(
                 $textAdventureUploader->uploadIsPossible(),
@@ -728,18 +732,32 @@ class TextAdventureUploaderTest extends TestCase
         }
     }
 
-    /**
-        *
     public function testUploadIsPossibleReturnsFalseIfFileToUploadIsAnHtmlFileReturnsFalse(): void
     {
 
+        $request = $this->mockCurrentRequest();
+        $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILENAME_INDEX]
+            = $request->getUniqueId();
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        if(
+            !$textAdventureUploader->fileToUploadIsAnHtmlFile()
+        ) {
+            $this->assertFalse(
+                $textAdventureUploader->uploadIsPossible(),
+                TextAdventureUploader::class .
+                '->uploadIsPossible() must ' .
+                'return false if ' .
+                TextAdventureUploader::class .
+                '->fileToUploadIsAnHtmlFile() ' .
+                'returns false'
+            );
+        }
     }
-     */
+
 }
-/**
-    *
-        $uploadIsPossible !== false
-        &&
-        !$textAdventureUploader->fileToUploadIsAnHtmlFile()
- */
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -427,4 +427,48 @@ class TextAdventureUploaderTest extends TestCase
             Request::class . ' was not previously stored.'
         );
     }
+
+
+    public function testPostRequestIdReturnsAnEmptyStringIfNotSetInCurrentRequestsPOSTData(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $this->assertEmpty(
+            $textAdventureUploader->postRequestId(),
+            TextAdventureUploader::class .
+            '->postRequestId() must return an empty ' .
+            'string if the specified ' . Request::class .
+            '\'s $_POST data does not contain a postRequestId.'
+        );
+    }
+
+    public function testPostRequestIdReturnsThePostRequestIdSetInTheCurrentRequestsPOSTData(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $request->import(
+            [
+                'post' => [
+                    'postRequestId' => $request->getUniqueId()
+                ]
+            ]
+        );
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $this->assertEquals(
+            $request->getUniqueId(),
+            $textAdventureUploader->postRequestId(),
+            TextAdventureUploader::class .
+            '->postRequestId() must return the value of the ' .
+            'postRequestId set in the specified ' .
+            Request::class . '\'s $_POST data if it is defined.'
+        );
+    }
 }
+/**
+ *
+ */

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -10,17 +10,6 @@ use roady\classes\component\Web\Routing\Request;
 use roady\classes\primary\Storable;
 use roady\classes\primary\Switchable;
 
-/**
- * Defines tests for the TextAdventureUploader.
- *
- * Methods:
- * public function tearDown(): void
- * public function testNameOfFileToUploadRetunrsTheString_NO_FILE_SELECTED_IfAFileHasNotBeenSelectedForUpload(): void
- * public function testPathToUploadFileToReturnsNameOfFileSelectedForUploadPrefixedByPathToUploadsDirectory(): void
- * public function testPathToUploadFileToReturnsTheString_NO_FILE_SELECTED_IfAFileHasNotBeenSelectedForUpload(): void
- * public function testPathToUploadsDirectoryReturnsExpectedPathToUploadsDirectory(): void
- *
- */
 class TextAdventureUploaderTest extends TestCase
 {
 
@@ -50,8 +39,11 @@ class TextAdventureUploaderTest extends TestCase
             $textAdventureUploader->nameOfFileToUpload()
         );
         /**
-         * Also test for case where $_FILES['fileToUpload']['name']
-         * is empty
+         * Also test for case where
+         * $_FILES
+         *     [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+         *     [TextAdventureUploader::FILENAME_INDEX]
+         * is empty.
          */
         $_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
                [TextAdventureUploader::FILENAME_INDEX] = '';
@@ -67,8 +59,10 @@ class TextAdventureUploaderTest extends TestCase
             $this->mockCurrentRequest(),
             $this->mockComponentCrud()
         );
-        $_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
-               [TextAdventureUploader::FILENAME_INDEX] = 'TwineFile.html';
+        $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILENAME_INDEX]
+            = 'TwineFile.html';
         $this->assertEquals(
             $_FILES["fileToUpload"]["name"],
             $textAdventureUploader->nameOfFileToUpload()
@@ -77,14 +71,19 @@ class TextAdventureUploaderTest extends TestCase
 
     public function testPathToUploadFileToReturnsTheNameOfFileToUploadPrefixedByThePathToUploadsDirectory(): void
     {
+        $request = $this->mockCurrentRequest();
         $textAdventureUploader = new TextAdventureUploader(
-            $this->mockCurrentRequest(),
+            $request,
             $this->mockComponentCrud()
         );
-        $_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
-               [TextAdventureUploader::FILENAME_INDEX] = 'TwineFile.html';
+        $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILENAME_INDEX]
+            = $request->getUniqueId() . '.html';
         $this->assertEquals(
-            $textAdventureUploader->pathToUploadsDirectory() . DIRECTORY_SEPARATOR . $textAdventureUploader->nameOfFileToUpload(),
+            $textAdventureUploader->pathToUploadsDirectory() .
+            DIRECTORY_SEPARATOR .
+            $textAdventureUploader->nameOfFileToUpload(),
             $textAdventureUploader->pathToUploadFileTo()
         );
     }
@@ -138,6 +137,22 @@ class TextAdventureUploaderTest extends TestCase
         );
     }
 
+    public function testPOST_REQUEST_ID_INDEXConstantIsAssignedTheString_postRequestId(): void
+    {
+        $this->assertEquals(
+            TextAdventureUploader::POST_REQUEST_ID_INDEX,
+            TextAdventureUploader::POST_REQUEST_ID_INDEX
+        );
+    }
+
+    public function testREPLACE_EXISTING_GAMEConstantIsAssignedTheString_replaceExistingGame(): void
+    {
+        $this->assertEquals(
+            TextAdventureUploader::REPLACE_EXISTING_GAME_INDEX,
+            TextAdventureUploader::REPLACE_EXISTING_GAME_INDEX
+        );
+    }
+
     public function testFILENAME_INDEXConstantIsAssignedTheString_name(): void
     {
         $this->assertEquals(
@@ -145,6 +160,16 @@ class TextAdventureUploaderTest extends TestCase
             TextAdventureUploader::FILENAME_INDEX,
             'TextAdventureUploader::FILENAME_INDEX constant must ' .
             'be assigned the string `name`.'
+        );
+    }
+
+    public function tesTEMPORARY_FILENAME_INDEXConstantIsAssignedTheString__tmp_name(): void
+    {
+        $this->assertEquals(
+            'tmp_name',
+            TextAdventureUploader::TEMPORARY_FILENAME_INDEX,
+            'TextAdventureUploader::TEMPORARY_FILENAME_INDEX constant must ' .
+            'be assigned the string `tmp_name`.'
         );
     }
 
@@ -178,7 +203,9 @@ class TextAdventureUploaderTest extends TestCase
             $this->mockCurrentRequest(),
             $this->mockComponentCrud()
         );
-        $_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX][TextAdventureUploader::FILENAME_INDEX] = 'foo.html';
+        $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILENAME_INDEX] = 'foo.html';
         $this->assertTrue(
             $textAdventureUploader->fileToUploadIsAnHtmlFile(),
             TextAdventureUploader::class .
@@ -345,8 +372,11 @@ class TextAdventureUploaderTest extends TestCase
             $this->mockComponentCrud()->read(
                 $currentRequest
             ),
-            'The specified ' . Request::class . ' must be stored on ' .
-            'instantiation of a new ' . TextAdventureUploader::class
+            'The specified ' .
+            Request::class .
+            ' must be stored on ' .
+            'instantiation of a new ' .
+            TextAdventureUploader::class
         );
     }
 
@@ -453,7 +483,7 @@ class TextAdventureUploaderTest extends TestCase
         $request->import(
             [
                 'post' => [
-                    'postRequestId' => $request->getUniqueId()
+                    TextAdventureUploader::POST_REQUEST_ID_INDEX => $request->getUniqueId()
                 ]
             ]
         );
@@ -466,7 +496,8 @@ class TextAdventureUploaderTest extends TestCase
             $textAdventureUploader->postRequestId(),
             TextAdventureUploader::class .
             '->postRequestId() must return the value of the ' .
-            'postRequestId set in the specified ' .
+            TextAdventureUploader::POST_REQUEST_ID_INDEX . ' ' .
+            'set in the specified ' .
             Request::class . '\'s $_POST data if it is defined.'
         );
     }
@@ -494,7 +525,8 @@ class TextAdventureUploaderTest extends TestCase
         $request->import(
             [
                 'post' => [
-                    'replaceExistingGame' => 'true'
+                    TextAdventureUploader::REPLACE_EXISTING_GAME_INDEX
+                    => 'true'
                 ]
             ]
         );
@@ -525,14 +557,18 @@ class TextAdventureUploaderTest extends TestCase
             TextAdventureUploader::class .
             '->fileToUploadsTemporaryName() must return the ' .
             'string `NO_FILE_SELECTED` if ' .
-            '`$_FILES["fileToUpload"]["tmp_name"]` is not set.'
+            '`$_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX][TextAdventureUploader::TEMPORARY_FILENAME_INDEX]` ' .
+            'is not set.'
         );
     }
 
     public function testFileToUploadsTemporaryNameReturnsValueAssignedTo_fileToUpload__tmp_name_IfItIsSetIn_FILES(): void
     {
         $request = $this->mockCurrentRequest();
-        $_FILES["fileToUpload"]["tmp_name"] = $request->getUniqueId();
+        $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::TEMPORARY_FILENAME_INDEX]
+            = $request->getUniqueId();
         $textAdventureUploader = new TextAdventureUploader(
             $request,
             $this->mockComponentCrud()
@@ -574,7 +610,9 @@ class TextAdventureUploaderTest extends TestCase
             $textAdventureUploader->pathToUploadsDirectory() .
             DIRECTORY_SEPARATOR .
             $request->getUniqueId();
-        if(!is_dir($textAdventureUploader->pathToUploadsDirectory())) {
+        if(
+            !is_dir($textAdventureUploader->pathToUploadsDirectory())
+        ) {
             mkdir($textAdventureUploader->pathToUploadsDirectory());
         }
         file_put_contents(
@@ -585,24 +623,66 @@ class TextAdventureUploaderTest extends TestCase
             [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
             [TextAdventureUploader::FILENAME_INDEX]
             = $request->getUniqueId();
-        $this->assertFalse(
-            $textAdventureUploader->uploadIsPossible(),
-            TextAdventureUploader::class .
-            '->uploadIsPossible() must return `false` if ' .
-            'a file was already uploaded whose name matches ' .
-            'the name of the file to upload, and the `' .
-            TextAdventureUploader::class .
-            '->replaceExistingGame()` method reuturns false.'
+        if(!$textAdventureUploader->replaceExistingGame()) {
+            $this->assertFalse(
+                $textAdventureUploader->uploadIsPossible(),
+                TextAdventureUploader::class .
+                '->uploadIsPossible() must return `false` if ' .
+                'a file was already uploaded whose name matches ' .
+                'the name of the file to upload, and the `' .
+                TextAdventureUploader::class .
+                '->replaceExistingGame()` method returns false.'
+            );
+        }
+        unlink($pathToTestFile);
+        rmdir($textAdventureUploader->pathToUploadsDirectory());
+    }
+
+    public function testUploadIsPossibleReturnsTrueIfAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUploadAndReplaceExistingGameReturnsTrue(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $request->import(
+            [
+                'post' => [
+                    TextAdventureUploader::REPLACE_EXISTING_GAME_INDEX
+                    => 'true'
+                ]
+            ]
         );
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $pathToTestFile =
+            $textAdventureUploader->pathToUploadsDirectory() .
+            DIRECTORY_SEPARATOR .
+            $request->getUniqueId();
+        if(
+            !is_dir($textAdventureUploader->pathToUploadsDirectory())
+        ) {
+            mkdir($textAdventureUploader->pathToUploadsDirectory());
+        }
+        file_put_contents(
+            $pathToTestFile,
+            $request->getName()
+        );
+        $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILENAME_INDEX]
+            = $request->getUniqueId();
+        if($textAdventureUploader->replaceExistingGame()) {
+            $this->assertTrue(
+                $textAdventureUploader->uploadIsPossible(),
+                TextAdventureUploader::class .
+                '->uploadIsPossible() must return `true` if ' .
+                'a file was already uploaded whose name matches ' .
+                'the name of the file to upload, and the `' .
+                TextAdventureUploader::class .
+                '->replaceExistingGame()` method returns true.'
+            );
+        }
         unlink($pathToTestFile);
         rmdir($textAdventureUploader->pathToUploadsDirectory());
     }
 }
-
-/**
-
-    $textAdventureUploader->replaceExistingGame() !== true
-    &&
-    file_exists($textAdventureUploader->pathToUploadFileTo())
- */
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -4,6 +4,8 @@ namespace Apps\TextAdventureImporter\resources\tests\utility;
 
 use Apps\TextAdventureImporter\resources\classes\utility\TextAdventureUploader;
 use PHPUnit\Framework\TestCase;
+use roady\classes\component\Crud\ComponentCrud;
+use roady\classes\component\Driver\Storage\FileSystem\JsonStorageDriver;
 use roady\classes\component\Web\Routing\Request;
 use roady\classes\primary\Storable;
 use roady\classes\primary\Switchable;
@@ -30,7 +32,8 @@ class TextAdventureUploaderTest extends TestCase
     public function testNameOfFileToUploadRetunrsTheValueOfTheNO_FILE_SELECTEDConstantIfAFileHasNotBeenSelectedForUpload(): void
     {
         $textAdventureUploader = new TextAdventureUploader(
-            $this->mockCurrentRequest()
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
         );
         $this->assertEquals(
              TextAdventureUploader::NO_FILE_SELECTED,
@@ -51,7 +54,8 @@ class TextAdventureUploaderTest extends TestCase
     public function testNameOfFileToUploadRetunrsTheNameOfTheFileToUploadIfAFileHasBeenSelectedForUpload(): void
     {
         $textAdventureUploader = new TextAdventureUploader(
-            $this->mockCurrentRequest()
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
         );
         $_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
                [TextAdventureUploader::FILENAME_INDEX] = 'TwineFile.html';
@@ -64,7 +68,8 @@ class TextAdventureUploaderTest extends TestCase
     public function testPathToUploadFileToReturnsTheNameOfFileToUploadPrefixedByThePathToUploadsDirectory(): void
     {
         $textAdventureUploader = new TextAdventureUploader(
-            $this->mockCurrentRequest()
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
         );
         $_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
                [TextAdventureUploader::FILENAME_INDEX] = 'TwineFile.html';
@@ -77,7 +82,8 @@ class TextAdventureUploaderTest extends TestCase
     public function testPathToUploadFileToReturnsTheString_NO_FILE_SELECTED_IfAFileHasNotBeenSelectedForUpload(): void
     {
         $textAdventureUploader = new TextAdventureUploader(
-            $this->mockCurrentRequest()
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
         );
         $this->assertEquals(
              TextAdventureUploader::NO_FILE_SELECTED,
@@ -88,7 +94,8 @@ class TextAdventureUploaderTest extends TestCase
     public function testPathToUploadsDirectoryReturnsExpectedPathToUploadsDirectory(): void
     {
         $textAdventureUploader = new TextAdventureUploader(
-            $this->mockCurrentRequest()
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
         );
         $expectedPath = (
             str_replace(
@@ -140,7 +147,8 @@ class TextAdventureUploaderTest extends TestCase
     public function testFileToUploadIsAnHtmlFileReturnsFalseIfFileSelcetedForUploadDoesNotHaveTheExtension_html(): void
     {
         $textAdventureUploader = new TextAdventureUploader(
-            $this->mockCurrentRequest()
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
         );
         $this->assertFalse(
             $textAdventureUploader->fileToUploadIsAnHtmlFile(),
@@ -154,7 +162,8 @@ class TextAdventureUploaderTest extends TestCase
     public function testFileToUploadIsAnHtmlFileReturnsTrueIfFileSelcetedForUploadHasTheExtension_html(): void
     {
         $textAdventureUploader = new TextAdventureUploader(
-            $this->mockCurrentRequest()
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
         );
         $_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX][TextAdventureUploader::FILENAME_INDEX] = 'foo.html';
         $this->assertTrue(
@@ -170,7 +179,8 @@ class TextAdventureUploaderTest extends TestCase
     {
         $currentRequest = $this->mockCurrentRequest();
         $textAdventureUploader = new TextAdventureUploader(
-            $currentRequest
+            $currentRequest,
+            $this->mockComponentCrud()
         );
         $this->assertEquals(
             $currentRequest->getUrl(),
@@ -191,7 +201,8 @@ class TextAdventureUploaderTest extends TestCase
         $currentRequest = $this->mockCurrentRequest();
         $currentRequest->import(['post' => ['post data']]);
         $textAdventureUploader = new TextAdventureUploader(
-            $currentRequest
+            $currentRequest,
+            $this->mockComponentCrud()
         );
         $this->assertEquals(
             $currentRequest->getPost(),
@@ -212,7 +223,8 @@ class TextAdventureUploaderTest extends TestCase
         $currentRequest = $this->mockCurrentRequest();
         $currentRequest->import(['get' => ['get data']]);
         $textAdventureUploader = new TextAdventureUploader(
-            $currentRequest
+            $currentRequest,
+            $this->mockComponentCrud()
         );
         $this->assertEquals(
             $currentRequest->getPost(),
@@ -245,24 +257,71 @@ class TextAdventureUploaderTest extends TestCase
         $_FILES["fileToUpload"]["size"] = 4999999;
         $currentRequest = $this->mockCurrentRequest();
         $textAdventureUploader = new TextAdventureUploader(
-            $currentRequest
+            $currentRequest,
+            $this->mockComponentCrud()
         );
         $this->assertFalse(
             $textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize(),
             ''
         );
     }
+
     public function testFileToUploadSizeExceedsAllowedFileSizeReturnsTrueIfSizeOfFileToUploadExceedsAllowedFileSizeOf_5000000_bytes(): void
     {
         $_FILES["fileToUpload"]["size"] = 5000001;
         $currentRequest = $this->mockCurrentRequest();
         $textAdventureUploader = new TextAdventureUploader(
-            $currentRequest
+            $currentRequest,
+            $this->mockComponentCrud()
         );
         $this->assertTrue(
             $textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize(),
             ''
         );
     }
+
+    public function mockComponentCrud(): ComponentCrud
+    {
+        return new ComponentCrud(
+            new Storable(
+                'TextAdventureUploaderTestComponentCrud',
+                'TextAdventureImporter',
+                'ComponentCruds'
+            ),
+            new Switchable(),
+            new JsonStorageDriver(
+                new Storable(
+                    'TextAdventureUploaderTestJsonStorageDriver',
+                    'TextAdventureImporter',
+                    'Drivers'
+                ),
+                new Switchable()
+            )
+        );
+    }
+
+    public function testComponentCrudReturnsAssignedComponentCrud(): void
+    {
+        $specifiedComponentCrud = $this->mockComponentCrud();
+        $textAdventureUploader = new TextAdventureUploader(
+            $this->mockCurrentRequest(),
+            $specifiedComponentCrud
+        );
+        $this->assertEquals(
+            $specifiedComponentCrud,
+            $textAdventureUploader->componentCrud()
+        );
+    }
+    /**
+        *
+    public function testSpecifiedRequestIsStoredOnInstantiation(): void
+    {
+        $currentRequest = $this->mockCurrentRequest();
+        $textAdventureUploader = new TextAdventureUploader(
+            $currentRequest,
+            $this->mockComponentCrud()
+        );
+    }
+     */
 }
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -128,19 +128,23 @@ class TextAdventureUploaderTest extends TestCase
         );
     }
 
-    public function testFILENAME_INDEXConstantIsAssignedTheString_fileToUpload(): void
+    public function testFILENAME_INDEXConstantIsAssignedTheString_name(): void
     {
         $this->assertEquals(
             'name',
-            TextAdventureUploader::FILENAME_INDEX
+            TextAdventureUploader::FILENAME_INDEX,
+            'TextAdventureUploader::FILENAME_INDEX constant must ' .
+            'be assigned the string `name`.'
         );
     }
 
-    public function testNO_FILE_SELECTEDConstantIsAssignedTheString_fileToUpload(): void
+    public function testNO_FILE_SELECTEDConstantIsAssignedTheString_NO_FILE_SELECTED(): void
     {
         $this->assertEquals(
             'NO_FILE_SELECTED',
-            TextAdventureUploader::NO_FILE_SELECTED
+            TextAdventureUploader::NO_FILE_SELECTED,
+            'TextAdventureUploader::NO_FILE_SELECTED constant must ' .
+            'be assigned the string `NO_FILE_SELECTED`.'
         );
     }
 
@@ -153,8 +157,7 @@ class TextAdventureUploaderTest extends TestCase
         $this->assertFalse(
             $textAdventureUploader->fileToUploadIsAnHtmlFile(),
             TextAdventureUploader::class .
-            '->' . __FUNCTION__ .
-            '() must return false if file '.
+            '->fileToUploadIsAnHtmlFile() must return false if file '.
             'to upload does not have the extension `html`.'
         );
     }
@@ -169,13 +172,12 @@ class TextAdventureUploaderTest extends TestCase
         $this->assertTrue(
             $textAdventureUploader->fileToUploadIsAnHtmlFile(),
             TextAdventureUploader::class .
-            '->' . __FUNCTION__ .
-            '() must return true if file '.
-            'to upload has the extension `html`.'
+            '->fileToUploadIsAnHtmlFile() must return true if' .
+            'file to upload does have the extension `html`.'
         );
     }
 
-    public function testCurrentRequestReturnsARequestInstanceWhoseUrlMatchesTheCurrentRequestsUrl(): void
+    public function testCurrentRequestReturnsARequestInstanceWhoseUrlMatchesTheRequestSpecifiedOnInstantiation(): void
     {
         $currentRequest = $this->mockCurrentRequest();
         $textAdventureUploader = new TextAdventureUploader(
@@ -186,9 +188,7 @@ class TextAdventureUploaderTest extends TestCase
             $currentRequest->getUrl(),
             $textAdventureUploader->currentRequest()->getUrl(),
             TextAdventureUploader::class .
-            '->' .
-            __FUNCTION__ .
-            '() must return a ' .
+            '->currentRequest() must return a ' .
             Request::class .
             ' instance whose url matches the url for the current' .
             'request.'
@@ -262,7 +262,10 @@ class TextAdventureUploaderTest extends TestCase
         );
         $this->assertFalse(
             $textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize(),
-            ''
+            TextAdventureUploader::class .
+            '->fileToUploadSizeExceedsAllowedFileSize() must ' .
+            'return false if size of file to upload does not ' .
+            'exceed the maximum allowed file size of 5000000 bytes.'
         );
     }
 
@@ -276,7 +279,10 @@ class TextAdventureUploaderTest extends TestCase
         );
         $this->assertTrue(
             $textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize(),
-            ''
+            TextAdventureUploader::class .
+            '->fileToUploadSizeExceedsAllowedFileSize() must ' .
+            'return true if size of file to upload exceeds ' .
+            'the maximum allowed file size of 5000000 bytes.'
         );
     }
 
@@ -309,11 +315,14 @@ class TextAdventureUploaderTest extends TestCase
         );
         $this->assertEquals(
             $specifiedComponentCrud,
-            $textAdventureUploader->componentCrud()
+            $textAdventureUploader->componentCrud(),
+            'The ' . TextAdventureUploader::class .
+            '->componentCrud() method must return the ' .
+            ComponentCrud::class . ' instance that was assigned on ' .
+            ' instantiation of a new ' . TextAdventureUploader::class
         );
     }
-    /**
-        *
+
     public function testSpecifiedRequestIsStoredOnInstantiation(): void
     {
         $currentRequest = $this->mockCurrentRequest();
@@ -321,7 +330,52 @@ class TextAdventureUploaderTest extends TestCase
             $currentRequest,
             $this->mockComponentCrud()
         );
+        $this->assertEquals(
+            $currentRequest,
+            $this->mockComponentCrud()->read(
+                $currentRequest
+            ),
+            'The specified ' . Request::class . ' must be stored on ' .
+            'instantiation of a new ' . TextAdventureUploader::class
+        );
     }
-     */
+
+    public function testSpecifiedRequestReplacesExistingStoredRequestWhoseNameTypeLocationAndContainerMatchSpecifiedRequestOnInstantiation(): void
+    {
+        $failureMessagePrefix =
+            'If a stored ' . Request::class . ' exists whose ' .
+            'name, type, location, and container match the ' .
+            'specified ' . Request::class . ', then the specified ' .
+            Request::class . ' must be used to update the stored ' .
+            Request::class . ' on instantiation of a new ' .
+            TextAdventureUploader::class . '.';
+        $currentRequest = $this->mockCurrentRequest();
+        $newRequest = $this->mockCurrentRequest();
+        $firstTextAdventureUploader = new TextAdventureUploader(
+            $currentRequest,
+            $this->mockComponentCrud()
+        );
+        $secondTextAdventureUploader = new TextAdventureUploader(
+            $newRequest,
+            $this->mockComponentCrud()
+        );
+        $this->assertNotEquals(
+            $currentRequest,
+            $this->mockComponentCrud()->read(
+                $currentRequest
+            ),
+            $failureMessagePrefix .
+            'The original ' . Request::class . ' was not updated.'
+        );
+        $this->assertEquals(
+            $newRequest,
+            $this->mockComponentCrud()->read(
+                $newRequest
+            ),
+            $failureMessagePrefix .
+            'The specified' . Request::class . ' was not stored.'
+        );
+
+    }
 }
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -563,17 +563,39 @@ class TextAdventureUploaderTest extends TestCase
         rmdir($textAdventureUploader->pathToUploadsDirectory());
     }
 
-    public function testUploadIsPossibleReturnsFalseIfAFileWithWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUpload(): void
+    public function testUploadIsPossibleReturnsFalseIfAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUploadAndReplaceExistingGameReturnsFalse(): void
     {
         $request = $this->mockCurrentRequest();
         $textAdventureUploader = new TextAdventureUploader(
             $request,
             $this->mockComponentCrud()
         );
-        $this->assertEquals(
-            $textAdventureUploader->nameOfFileToUpload(),
-            $textAdventureUploader->nameOfFileToUpload()
+        $pathToTestFile =
+            $textAdventureUploader->pathToUploadsDirectory() .
+            DIRECTORY_SEPARATOR .
+            $request->getUniqueId();
+        if(!is_dir($textAdventureUploader->pathToUploadsDirectory())) {
+            mkdir($textAdventureUploader->pathToUploadsDirectory());
+        }
+        file_put_contents(
+            $pathToTestFile,
+            $request->getName()
         );
+        $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILENAME_INDEX]
+            = $request->getUniqueId();
+        $this->assertFalse(
+            $textAdventureUploader->uploadIsPossible(),
+            TextAdventureUploader::class .
+            '->uploadIsPossible() must return `false` if ' .
+            'a file was already uploaded whose name matches ' .
+            'the name of the file to upload, and the `' .
+            TextAdventureUploader::class .
+            '->replaceExistingGame()` method reuturns false.'
+        );
+        unlink($pathToTestFile);
+        rmdir($textAdventureUploader->pathToUploadsDirectory());
     }
 }
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -759,5 +759,99 @@ class TextAdventureUploaderTest extends TestCase
         }
     }
 
+    public function testUploadIsPossibleReturnsFalseIfNameOfFileToUploadReturnsTheString_NO_FILE_SELECTED(): void
+    {
+        $textAdventureUploader = new TextAdventureUploader(
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
+        );
+        if(
+            $textAdventureUploader->nameOfFileToUpload()
+            ===
+            TextAdventureUploader::NO_FILE_SELECTED
+        ) {
+            $this->assertFalse(
+                $textAdventureUploader->uploadIsPossible(),
+                TextAdventureUploader::class .
+                '->uploadIsPossible() must return false ' .
+                'if ' . TextAdventureUploader::class .
+                '->nameOfFileToUpload() returns the string' .
+                TextAdventureUploader::NO_FILE_SELECTED
+            );
+        }
+    }
+
+    public function testUploadIsPossibleReturnsFalseIfPreviousRequestIdDoesNotMatchPostRequestId(): void
+    {
+        $textAdventureUploader = new TextAdventureUploader(
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
+        );
+        if(
+            $textAdventureUploader->previousRequest()->getUniqueId()
+            !==
+            $textAdventureUploader->postRequestId()
+        ) {
+            $this->assertFalse(
+                $textAdventureUploader->uploadIsPossible(),
+                TextAdventureUploader::class .
+                '->uploadIsPossible() must return false ' .
+                'if the id returned by ' .
+                TextAdventureUploader::class .
+                '->postRequestId() does not match the ' .
+                'the previous ' . Request::class . '\'s ' .
+                'unique id.'
+            );
+        }
+    }
 }
+
+/**
+ *
+$aFileWasNotSelectedMessage = '
+    <p class="roady-error-message">
+        A Twine html file was not selected.
+        Please select a Twine html file to upload!
+    </p>
+';
+$invalidFileTypeMessage = '
+    <p class="roady-error-message">
+        Only Twine html files can be uploaded!
+        Please select a Twine html file to upload
+    </p>
+';
+$fileIsToLargeMessage = '
+    <p class="roady-error-message">
+        The file is too large!
+    </p>
+';
+
+$theSpecifiedTwineFileWasAlreadyImportedMessage = "
+    <div class=\"roady-error-message\">
+        <p>
+            A Twine file with the same name was already
+            uploaded.
+        </p>
+        <p>
+            Please upload a Twine file with a unique name,
+            or check the <span>Replace Existing App</span>
+            check box below.
+        </p>
+    </div>
+";
+
+$fileUploadedSuccessfullyMessage = "
+    <p class=\"roady-success-message\">
+        The file ".
+        htmlspecialchars(
+            basename($textAdventureUploader->nameOfFileToUpload())
+        ) .
+    " has been uploaded.
+    </p>";
+
+$failedToUploadFileMessage = "
+    <p class=\"roady-error-message\">
+        Sorry, there was an error uploading your file.
+    </p>";
+ */
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -15,7 +15,7 @@ class TextAdventureUploaderTest extends TestCase
 
     public function tearDown(): void
     {
-        unset($_FILES["fileToUpload"]);
+        unset($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]);
         foreach(
             $this->mockComponentCrud()
                  ->readAll(
@@ -64,7 +64,9 @@ class TextAdventureUploaderTest extends TestCase
             [TextAdventureUploader::FILENAME_INDEX]
             = 'TwineFile.html';
         $this->assertEquals(
-            $_FILES["fileToUpload"]["name"],
+            $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILENAME_INDEX],
             $textAdventureUploader->nameOfFileToUpload()
         );
     }
@@ -129,6 +131,14 @@ class TextAdventureUploaderTest extends TestCase
         );
     }
 
+    public function testFILE_TO_UPLOAD_SIZE_INDEXConstantIsAssignedTheString_size(): void
+    {
+        $this->assertEquals(
+            'size',
+            TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX
+        );
+    }
+
     public function testFILE_TO_UPLOAD_INDEXConstantIsAssignedTheString_fileToUpload(): void
     {
         $this->assertEquals(
@@ -168,8 +178,8 @@ class TextAdventureUploaderTest extends TestCase
         $this->assertEquals(
             'tmp_name',
             TextAdventureUploader::TEMPORARY_FILENAME_INDEX,
-            'TextAdventureUploader::TEMPORARY_FILENAME_INDEX constant must ' .
-            'be assigned the string `tmp_name`.'
+            'TextAdventureUploader::TEMPORARY_FILENAME_INDEX ' .
+            'constant must be assigned the string `tmp_name`.'
         );
     }
 
@@ -291,7 +301,7 @@ class TextAdventureUploaderTest extends TestCase
 
     public function testFileToUploadSizeExceedsAllowedFileSizeReturnsFalseIfSizeOfFileToUploadDoesNotExceedAllowedFileSizeOf_5000000_bytes(): void
     {
-        $_FILES["fileToUpload"]["size"] = 4999999;
+        $_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX][TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX] = 4999999;
         $currentRequest = $this->mockCurrentRequest();
         $textAdventureUploader = new TextAdventureUploader(
             $currentRequest,
@@ -308,7 +318,7 @@ class TextAdventureUploaderTest extends TestCase
 
     public function testFileToUploadSizeExceedsAllowedFileSizeReturnsTrueIfSizeOfFileToUploadExceedsAllowedFileSizeOf_5000000_bytes(): void
     {
-        $_FILES["fileToUpload"]["size"] = 5000001;
+        $_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX][TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX] = 5000001;
         $currentRequest = $this->mockCurrentRequest();
         $textAdventureUploader = new TextAdventureUploader(
             $currentRequest,
@@ -483,7 +493,8 @@ class TextAdventureUploaderTest extends TestCase
         $request->import(
             [
                 'post' => [
-                    TextAdventureUploader::POST_REQUEST_ID_INDEX => $request->getUniqueId()
+                    TextAdventureUploader::POST_REQUEST_ID_INDEX
+                    => $request->getUniqueId()
                 ]
             ]
         );
@@ -557,8 +568,11 @@ class TextAdventureUploaderTest extends TestCase
             TextAdventureUploader::class .
             '->fileToUploadsTemporaryName() must return the ' .
             'string `NO_FILE_SELECTED` if ' .
-            '`$_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX][TextAdventureUploader::TEMPORARY_FILENAME_INDEX]` ' .
-            'is not set.'
+            '`$_FILES[' .
+            TextAdventureUploader::FILE_TO_UPLOAD_INDEX .
+            '][' .
+            TextAdventureUploader::TEMPORARY_FILENAME_INDEX .
+            ']` is not set.'
         );
     }
 
@@ -578,8 +592,12 @@ class TextAdventureUploaderTest extends TestCase
             $textAdventureUploader->fileToUploadsTemporaryName(),
             TextAdventureUploader::class .
             '->fileToUploadsTemporaryName() must return an ' .
-            'empty string if $_FILES["fileToUpload"]["name"] is ' .
-            'not set.'
+            'empty string if ' .
+            '$_FILES[' .
+            TextAdventureUploader::FILE_TO_UPLOAD_INDEX .
+            '][' .
+            TextAdventureUploader::FILENAME_INDEX .
+            '] is not set.'
         );
     }
 
@@ -687,7 +705,10 @@ class TextAdventureUploaderTest extends TestCase
 
     public function testUploadIsPossibleReturnsFalseIfFileToUploadSizeExceedsAllowedFileSizeReturnsTrue(): void
     {
-        $_FILES["fileToUpload"]["size"] = 5000001;
+        $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX]
+            = 5000001;
         $textAdventureUploader = new TextAdventureUploader(
             $this->mockCurrentRequest(),
             $this->mockComponentCrud()
@@ -706,11 +727,19 @@ class TextAdventureUploaderTest extends TestCase
             );
         }
     }
+
+    /**
+        *
+    public function testUploadIsPossibleReturnsFalseIfFileToUploadIsAnHtmlFileReturnsFalse(): void
+    {
+
+    }
+     */
 }
 /**
     *
         $uploadIsPossible !== false
         &&
-        $textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize()
+        !$textAdventureUploader->fileToUploadIsAnHtmlFile()
  */
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -578,14 +578,35 @@ class TextAdventureUploaderTest extends TestCase
         );
     }
 
-    /**
-     *
-    public function testUploadIsPossibleReturnsFalseIf(): void
+    public function testUploadCreatesUploadsDirectoryIfItDoesNotExist(): void
     {
+        $textAdventureUploader = new TextAdventureUploader(
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
+        );
+        $textAdventureUploader->upload();
+        $this->assertTrue(
+            is_dir($textAdventureUploader->pathToUploadsDirectory()),
+            'The ' . TextAdventureUploader::class . '->upload() ' .
+            'method must create the uploads directory if it does ' .
+            'not exist'
+        );
+        rmdir($textAdventureUploader->pathToUploadsDirectory());
     }
-        $textAdventureUploader->replaceExistingGame() !== true
-        &&
-        file_exists($textAdventureUploader->pathToUploadFileTo())
-     */
 }
+
+/**
+
+    public function testUploadIsPossibleReturnsFalseIfAFileWithTheSameNameAsTheFileToUploadWasAlreadyUploaded(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+    }
+    $textAdventureUploader->replaceExistingGame() !== true
+    &&
+    file_exists($textAdventureUploader->pathToUploadFileTo())
+ */
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -429,18 +429,20 @@ class TextAdventureUploaderTest extends TestCase
     }
 
 
-    public function testPostRequestIdReturnsAnEmptyStringIfNotSetInCurrentRequestsPOSTData(): void
+    public function testPostRequestIdReturnsTheString_NO_FILE_SELECTED_IfPostRequestIdIsNotSetInCurrentRequestsPOSTData(): void
     {
         $request = $this->mockCurrentRequest();
         $textAdventureUploader = new TextAdventureUploader(
             $request,
             $this->mockComponentCrud()
         );
-        $this->assertEmpty(
+        $this->assertEquals(
+            TextAdventureUploader::NO_FILE_SELECTED,
             $textAdventureUploader->postRequestId(),
             TextAdventureUploader::class .
-            '->postRequestId() must return an empty ' .
-            'string if the specified ' . Request::class .
+            '->postRequestId() must return the ' .
+            'string `NO_FILE_SELECTED` if the specified ' .
+            Request::class .
             '\'s $_POST data does not contain a postRequestId.'
         );
     }
@@ -510,19 +512,20 @@ class TextAdventureUploaderTest extends TestCase
         );
     }
 
-    public function testFileToUploadsTemporaryNameReturnsAnEmptyStringIf_fileToUpload__tmp_name_IsNotSetIn_FILES(): void
+    public function testFileToUploadsTemporaryNameReturnsTheString_NO_FILE_SELECTED_If_fileToUpload__tmp_name_IsNotSetIn_FILES(): void
     {
         $request = $this->mockCurrentRequest();
         $textAdventureUploader = new TextAdventureUploader(
             $request,
             $this->mockComponentCrud()
         );
-        $this->assertEmpty(
+        $this->assertEquals(
+            TextAdventureUploader::NO_FILE_SELECTED,
             $textAdventureUploader->fileToUploadsTemporaryName(),
             TextAdventureUploader::class .
-            '->fileToUploadsTemporaryName() must return an ' .
-            'empty string if $_FILES["fileToUpload"]["tmp_name"] ' .
-            'is not set.'
+            '->fileToUploadsTemporaryName() must return the ' .
+            'string `NO_FILE_SELECTED` if ' .
+            '`$_FILES["fileToUpload"]["tmp_name"]` is not set.'
         );
     }
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -509,5 +509,39 @@ class TextAdventureUploaderTest extends TestCase
             'string `true`.'
         );
     }
+
+    public function testFileToUploadsActualNameReturnsAnEmptyStringIf_fileToUpload_name_IsNotSetIn_FILES(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $this->assertEmpty(
+            $textAdventureUploader->fileToUploadsActualName(),
+            TextAdventureUploader::class .
+            '->fileToUploadsActualName() must return an ' .
+            'empty string if $_FILES["fileToUpload"]["name"] is ' .
+            'not set'
+        );
+    }
+
+    public function testFileToUploadsActualNameReturnsValueAssignedTo_fileToUpload_name_IsSetIn_FILES(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $_FILES["fileToUpload"]["name"] = $request->getUniqueId();
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $this->assertEquals(
+            $request->getUniqueId(),
+            $textAdventureUploader->fileToUploadsActualName(),
+            TextAdventureUploader::class .
+            '->fileToUploadsActualName() must return an ' .
+            'empty string if $_FILES["fileToUpload"]["name"] is ' .
+            'not set'
+        );
+    }
 }
 

--- a/roadyDarkTheme/css/global-colors.css
+++ b/roadyDarkTheme/css/global-colors.css
@@ -114,6 +114,17 @@ body {
     color: var(--light-tone-complimentery-color);
 }
 
+.roady-form input[type=file] {
+    color: var(--light-tone-analagous-color-2);
+    background: var(--dark-tone-monochromatic-color);
+    border-color: var(--dark-tone-complimentery-color);
+    /** @todo move to appropriate stylesheet */
+    width: 100%;
+    border: 0.3333333rem dotted;
+    border-radius: 5%;
+    padding: 1rem 42%;
+}
+
 /** Code Previews */
 
 .roady-inline-code {

--- a/roadyDarkTheme/css/global-colors.css
+++ b/roadyDarkTheme/css/global-colors.css
@@ -181,14 +181,14 @@ body {
 
 .roady-ol-list li:nth-of-type(even),
 .roady-ul-list li:nth-of-type(even) {
-    background-color: var(--gray-tone-triadic-color-1);
-    color: var(--light-tone-triadic-color-1);
+    background-color: var(--dark-tone-monochromatic-color);
+    color: var(--white);
 }
 
 .roady-ol-list li:nth-of-type(odd),
 .roady-ul-list li:nth-of-type(odd) {
-    background-color: var(--gray-tone-monochromatic-color);
-    color: var(--white);
+    background-color: var(--dark-tone-analagous-color-1);
+    color: var(--light-tone-triadic-color-2);
 }
 
 /** Messages */


### PR DESCRIPTION
commit 9e21548d9701b854da71f35a76b2b2cf1c33adb2
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 8 17:50:55 2022 -0400

    Working on TextAdventureImporter. Mocking building of App after conversion of uploaded file to a roady App

commit a7e633de94cc782cd89e723f88039386349c3697
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 8 17:18:01 2022 -0400

    Working on TextAdventureImporter. Finished mocking conversion of uploaded file into a roady App

commit ea50ee585c03c774bc92008c096790fa4996ac02
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 8 16:47:14 2022 -0400

    Working on TextAdventureImporter.
    
    Continued mocking conversion of uploaded file into a roady App.

commit 11737a17daca7dcfa62340c3af312876182fa2c5
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 8 16:42:14 2022 -0400

    Working on TextAdventureImporter.
    
    Began mocking conversion of uploaded file into a roady App.

commit 94421a617db99ff19a329ce38307634546f0c526
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 8 15:16:52 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented the following new test methods in
    `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
    - `testUploadIsPossibleReturnsFalseIfNameOfFileToUploadReturnsTheString_NO_FILE_SELECTED()`
    - `testUploadIsPossibleReturnsFalseIfPreviousRequestIdDoesNotMatchPostRequestId()`
    
    Code clean up in `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`

commit 8e7455c3960321cd76c590424920fd2f10102769
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 8 14:38:55 2022 -0400

    Working on TextAdventureImporter.
    
    Refactored
    `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`,
    removed verification that file to upload has the `.html` extension,
    this is now handled by the `TextAdventureUploader->uploadIsPossible()`
    method.

commit 1c062f58e2d62c8ddb6d5748bdcf3a54df6ade11
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 8 14:27:13 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented new test method `testUploadIsPossibleReturnsFalseIfFileToUploadIsAnHtmlFileReturnsFalse()`
    in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
    Code clean up in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    and `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`

commit a2f92b3cfc6f88b04e2ed8e038cfad283a5774a3
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 8 11:37:53 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented new test
    `testFILE_TO_UPLOAD_SIZE_INDEXConstantIsAssignedTheString_size()`
    in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
    Defined new constant `FILE_TO_UPLOAD_SIZE_INDEX` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    
    Refactored the following files to use defined TextAdventureUploader
    constants where appropriate:
    
    - `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    - `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`

commit 82fc406fd7b8498ca7fe91d7bf6190b4798f8338
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 8 04:56:09 2022 -0400

    Defined new styles for `.roady-form input[type=file]` in
    `roadyDarkTheme/css/global-colors.css`.
    
    Working on TextAdventureImporter.
    
    Implmeneted new test method
    `testUploadIsPossibleReturnsFalseIfFileToUploadSizeExceedsAllowedFileSizeReturnsTrue()`
    in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
    Code clean up.

commit 12a2d0e11fef8980517022a1d5363002e3089365
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 8 02:20:33 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented the following new test methods in
    `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:
    
    - `testUploadIsPossibleReturnsTrueIfAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUploadAndReplaceExistingGameReturnsTrue()`
    - `tesTEMPORARY_FILENAME_INDEXConstantIsAssignedTheString__tmp_name()`
    - `testREPLACE_EXISTING_GAMEConstantIsAssignedTheString_replaceExistingGame()`
    - `testPOST_REQUEST_ID_INDEXConstantIsAssignedTheString_postRequestId()`
    
    Implemented the following new constants in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`:
    
    - POST_REQUEST_ID_INDEX
    - REPLACE_EXISTING_GAME_INDEX
    - TEMPORARY_FILENAME_INDEX
    
    Refactored the following files to use new constants where appropriate:
    
    - `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    - `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    - `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    
    Code clean up in the following files:
    
    - `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    - `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    - `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`

commit 247b78128791f348a3a909876563f98d443d8a5a
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sat May 7 16:51:31 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented new test method
    `testUploadIsPossibleReturnsFalseIfAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUploadAndReplaceExistingGameReturnsFalse()`
    in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
    Implmented new method `uploadIsPossible()` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    
    Cleaned up code in `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`

commit 1ffb193032e1be226a69e38ef795967645936a3f
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sat May 7 15:37:39 2022 -0400

    Working on TextAdventureImporter.
    
    Refactored test method
    `testPostRequestIdReturnsAnEmptyStringIfNotSetInCurrentRequestsPOSTData()`
    to instead be `testPostRequestIdReturnsTheString_NO_FILE_SELECTED_IfPostRequestIdIsNotSetInCurrentRequestsPOSTData()`
    in TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php.
    
    Refactored test method
    `testFileToUploadsTemporaryNameReturnsAnEmptyStringIf_fileToUpload__tmp_name_IsNotSetIn_FILES()`
    to instead be
    `testFileToUploadsTemporaryNameReturnsTheString_NO_FILE_SELECTED_If_fileToUpload__tmp_name_IsNotSetIn_FILES()`
    in TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php.
    
    Refactored method `postRequestId()` to return
    `TextAdventureUploader::NO_FILE_SELECTED` if
    a `postRequestId` is not set in the specified
    `Request`'s `$_POST` data.
    
    Refactored method `fileToUploadsTemporaryName()` to return
    `TextAdventureUploader::NO_FILE_SELECTED` if
    a temporary file name is not set in the
    `$_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]` array.

commit 62684558eada373e305d79eabcb576399fda5895
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sat May 7 15:05:39 2022 -0400

    Working on TextAdventureImporter.
    
    Refactored `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
    - Code clean up.
    - Removed `testFileToUploadsActualNameReturnsAnEmptyStringIf_fileToUpload_name_IsNotSetIn_FILES()`
    - Removed `testFileToUploadsActualNameReturnsValueAssignedTo_fileToUpload_name_IfItIsSetIn_FILE()`
    
    Refactored `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    
    - Replaced calls to `TextAdventureUploader->fileToUploadsActualName()`
      with call `TextAdventureUploader->nameOfFileToUpload()`.
    
    Refactored `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    
    - Removed `fileToUploadsActualName()`

commit 6716e6bc2e49400159570b0a8a05b76bbf793e4b
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sat May 7 13:00:19 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented new test method
    `testUploadCreatesUploadsDirectoryIfItDoesNotExist()`.
    in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
    Began implementing new method `upload()` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    
    Refactored  `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    to begin utilizing the new `TextAdventureUploader->upload()` method.

commit 10a75af1a4b9ab77f1c8a7fa3a3e36ee1a5126f8
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sat May 7 02:45:43 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented the following new test methods in
    `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
    - `testFileToUploadsTemporaryNameReturnsAnEmptyStringIf_fileToUpload__tmp_name_IsNotSetIn_FILES()`
    - `testFileToUploadsTemporaryNameReturnsValueAssignedTo_fileToUpload__tmp_name_IfItIsSetIn_FILES()`
    
    Also renamed test method
    `testFileToUploadsActualNameReturnsValueAssignedTo_fileToUpload_name_IsSetIn_FILES()`
    to
    `testFileToUploadsActualNameReturnsValueAssignedTo_fileToUpload_name_IfItIsSetIn_FILES()`.
    
    Implemented new method `fileToUploadsTemporaryName()` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.
    
    Refactored
    `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`:
    
    - Cleaned up code.
    - Refactored uses of `$_FILES["fileToUpload"]["tmp_name"]` to instead
      use `$textAdventureUploader->fileToUploadsTemporaryName()`.

commit ee462a32017c2ca908a6e8f44b3c7ce13ccfee53
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Fri May 6 14:05:50 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented the following new test methods in
    `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
    - `testFileToUploadsActualNameReturnsAnEmptyStringIf_fileToUpload_name_IsNotSetIn_FILES()`
    - `testFileToUploadsActualNameReturnsValueAssignedTo_fileToUpload_name_IsSetIn_FILES()`
    
    Implemented new method `fileToUploadsActualName()` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.
    
    Refactored `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    to utilize new TextAdventureUploader methods. Also cleaned up code.

commit 699e8b661e6782fe030886d4a76b1aaa0d9cf4ac
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Fri May 6 04:05:21 2022 -0400

    Working on TextAdventureImporter.
    
    Refactored `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    to utilize new `TextAdventureUploader->replaceExistingGame()` method.

commit 5369e46104bde6104720f6b2f7a199374d11eb41
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Fri May 6 03:58:06 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented the following new test methods in
    `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:
    
    - `testReplaceExistingGameReturnsFalseIfValueSetInSpecifiedRequestsPOSTDataForReplaceExistingGameIsNotSetToTheString_true()`
    - `testReplaceExistingGameReturnsTrueIfValueSetInSpecifiedRequestsPOSTDataForReplaceExistingGameIsSetToTheString_true()`
    
    Implemented new method `replaceExistingGame()` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.

commit 8439b826a9bde3efc230e2dcb7163364b4d01013
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Fri May 6 03:30:35 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented the following new test methods in
    `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:
    
    - `testPostRequestIdReturnsAnEmptyStringIfNotSetInCurrentRequestsPOSTData()`
    - `testPostRequestIdReturnsThePostRequestIdSetInTheCurrentRequestsPOSTData()`
    
    Implemented new method `postRequestId()` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    
    Refactored `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    to utilize new `TextAdventureUploader->postRequestId()` method.

commit 4aa262b27764fc80ed56e9ac185f2e48c844f412
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Fri May 6 02:56:08 2022 -0400

    Working on TextAdventureImporter.
    
    Refactored `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    to utilize the following new TextAdventureUploader methods where
    appropriate:
    
    - previousRequest()
    - currentRequest()

commit 0c4af5904aaf26903b4dd92b77ef259b0184c4d1
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Thu May 5 16:26:43 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented the following new test methods in
    `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:
    
    - `testPreviousRequestReturnsSpecifiedRequestIfARequestWasNotPreviouslyStored()`
    - `testPreviousRequestReturnsPreviouslyStoredRequest()`
    
    Also refactored `tearDown()` method to remove Requests created
    by tests from storage.
    
    Implemented new method `previousRequest()` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.

commit 59e6f894c0657d6a92bd129ea28419dabba4fbd0
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Thu May 5 03:26:37 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented new test method
    `testSpecifiedRequestReplacesExistingStoredRequestWhoseNameTypeLocationAndContainerMatchSpecifiedRequestOnInstantiation()`
    in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    Also added test failure messages where missing.
    
    Code clean up in `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`.
    
    Implemented new method `testSpecifiedRequestIsStoredOnInstantiation()`
    in `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`

commit d583e415287814c938b208fdbf686bb49a231ed7
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Wed May 4 16:38:37 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented new test method
    `testComponentCrudReturnsAssignedComponentCrud()`
    in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
    Implemented new method `componentCrud()` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    
    Code clean up in `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`

commit d1f0d20e88ced98b992cede6b3ce90f833c3ecfb
Merge: df18981 6b4398d
Author: Sevi D <sevidmusic@gmail.com>
Date:   Mon May 2 15:14:08 2022 -0400

    Merge pull request #63 from sevidmusic/roadyAppPackages1651514722
    
    Refactored `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    to store current `Request` as last `Request` so that the `lastRequestId`
    stored in `$_POST` can be checked against the id of the stored `Request`
    prior to processing a `Request` to upload a Twine file.
    
    If the `lastRequestId` stored in `$_POST` does not match the `uniqueId` of the stored
    `Request`, then the `Request` to upload a Twine file will not be processed.
    
    Also, refactored `devMenu/DynamicOutput/devMenu.php`, added link to `?request=TextAdventureImporter`

commit 6b4398d7a243137c108386981d608f9fdc986c31
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Mon May 2 15:04:47 2022 -0400

    Working on TextAdventureImporter.
    
    Refactored `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    to store current Request as last Request so that the lastRequestId
    stored in $_POST can be checked against the id of the stored Request
    prior to processing a Request to upload a Twine file.

commit df18981590c811bdbe3875e98491b300d8f20e44
Merge: cdc8b27 69a22a0
Author: Sevi D <sevidmusic@gmail.com>
Date:   Tue Apr 26 15:42:03 2022 -0400

    Merge pull request #62 from sevidmusic/roady1650648154
    
    commit 69a22a0de667e3d10512e3f3268070fcdd9aa82e
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Mon Apr 25 01:18:50 2022 -0400
    
        Working on TextAdventureImporter.
    
        Implemented the following new tests in
        `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
        - `testFileToUploadSizeExceedsAllowedFileSizeReturnsFalseIfSizeOfFileToUploadDoesNotExceedAllowedFileSizeOf_5000000_bytes()`
        -
        `testFileToUploadSizeExceedsAllowedFileSizeReturnsTrueIfSizeOfFileToUploadExceedsAllowedFileSizeOf_5000000_bytes()`
    
        Implemented new method `fileToUploadSizeExceedsAllowedFileSize()` in
        `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    
        Code clean up in files mentioned above, and also in
        `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    
    commit d9fa99048d1c305747c126da4d9b3edb0ed2b8d1
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sun Apr 24 13:56:48 2022 -0400
    
        Working on TextAdventureImporter.
    
        Refactored TextAdventureUploader to expect an instance of a
        Request be passed to it's `__construct()` method in
        `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    
        Implemented the following new test methods in
        `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:
    
        - `testFileToUploadIsAnHtmlFileReturnsTrueIfFileSelcetedForUploadHasTheExtension_html()`
        - `testCurrentRequestReturnsARequestInstanceWhosePostDataMatchesTheCurrentRequestsPostData()`
        - `testCurrentRequestReturnsARequestInstanceWhoseGetDataMatchesTheCurrentRequestsGetData()`
    
        Code clean up in TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
    
    commit df38185b7c073b8db3146938d7a0d24f3004b69c
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sun Apr 24 12:19:21 2022 -0400
    
        Working on TextAdventureImporter.
    
        Cleaned up `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    
    commit d2604bd43ab8573e4dd6c28e61a43c1025c06541
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sun Apr 24 11:53:36 2022 -0400
    
        Working on TextAdventureImporter.
    
        Implemented new test methd `testCurrentRequestReturnsARequestInstanceWhoseUrlMatchesTheCurrentRequestsUrl()`
        in  `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
        Implemented new method `currentRequest()` in
        `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    
    commit ab251a97c745c42aa88c75c8a6029e7f42a4272e
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sun Apr 24 11:30:41 2022 -0400
    
        Working on TextAdventureImporter.
    
        Implemented new test method
        `testFileToUploadIsAnHtmlFileReturnsFalseIfFileSelcetedForUploadDoesNotHaveTheExtension_html()`
        in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
        Implemented new method `fileToUploadIsAnHtmlFile()` in
        `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.
    
    commit da4e59330a56e74ac181fe571f0abac62e5bb9b0
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sun Apr 24 10:53:16 2022 -0400
    
        Working on TextAdventureImporter.
    
        Began refactoring `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
        to utilize Apps\TextAdventureImporter\resources\classes\utility\TextAdventureUploader
    
    commit e4c6c4c3a41b0fb091018cdb5e45f85b5d79dc4b
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sun Apr 24 04:22:59 2022 -0400
    
        Working on TextAdventureImporter.
    
        Code clean up.
    
        Began using the TextAdventureImporter in `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`.
    
        Implemented the following tests in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
        ```
        public function testFILE_TO_UPLOAD_INDEXConstantIsAssignedTheString_fileToUpload(): void
    
        public function testFILENAME_INDEXConstantIsAssignedTheString_fileToUpload(): void
    
        public function testNO_FILE_SELECTEDConstantIsAssignedTheString_fileToUpload(): void
        ```
    
        Renamed `testNameOfFileToUploadRetunrsTheString_NO_FILE_SELECTED_IfAFileHasNotBeenSelectedForUpload()`
        test method to
        `testNameOfFileToUploadRetunrsTheValueOfTheNO_FILE_SELECTEDConstantIfAFileHasNotBeenSelectedForUpload`,
        and refactored it to also test for case where $_FILES['fileToUpload']['name']
        is empty in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
    commit 542e16c4a4d9a3092c1c88bed0b46acb683d3590
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sun Apr 24 03:27:56 2022 -0400
    
        Working on TextAdventureImporter
    
    commit 566c919e15a4b6e3881c47db9da83e2cd6c22ade
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sun Apr 24 02:57:48 2022 -0400
    
        Working on TextAdventureImporter. Updated README.md
    
    commit f29aefa0d6da7b50db022cd80b9daf2e3bd694b9
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sun Apr 24 02:49:49 2022 -0400
    
        Working on TextAdventureImporter. Added README.md
    
    commit db5b065c9be6f485a52c58086915bb36e386b009
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sat Apr 23 18:37:19 2022 -0400
    
        Working on TextAdventureImporter.
    
        Implemented new test method
        `testPathToUploadFileToReturnsNameOfFileSelectedForUploadPrefixedByPathToUploadsDirectory()`
        in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
        Refactored method `pathToUploadsDirectory()` in
        `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
        to pass new test.
    
    commit 0c96403ee69fe82f9a4ba21b68334e3b2395514c
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sat Apr 23 18:29:12 2022 -0400
    
        Working on TextAdventureImporter.
    
        Refactored test method
        `testPathToUploadFileToReturnsTheString_NO_FILE_SELECTED_IfAFileHasNotBeenSelectedForUpload`
        in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
        Refactored method `pathToUploadFileTo()` in
        `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.
    
        Original test logic was wrong.
    
    commit 60e46028ccc99dae09b93d0efe3cf0cc06c438e9
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sat Apr 23 18:02:46 2022 -0400
    
        Working on TextAdventureImporter.
    
        Renamed method `uploadsDirectroyPath()` to `pathToUploadsDirectory()`
        in `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.
    
        Renamed test method
        `testUploadsDirectoryPathReturnsExpectedPathToUploadsDirectory()` to
        `testPathToUploadsDirectoryReturnsExpectedPathToUploadsDirectory()` in
        `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
        Implemented new test,
        `testPathToUploadFileToReturnsTheString_NO_FILE_SELECTED_IfAFileHasNotBeenSelectedForUpload()`.
        in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
        Implemented new method, `pathToUploadFileTo()` in
        in `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.
    
    commit f1036837f8f42643ed52966b64f3cf30d535191b
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sat Apr 23 17:45:40 2022 -0400
    
        Working on TextAdventureImporter.
    
        Implemented the following:
    
        - `TextAdventureImporter\resources\tests\utility\TextAdventureUploaderTest->testUploadsDirectoryPathReturnsExpectedPathToUploadsDirectory()`
        - `TextAdventureImporter\resources\classes\utility\TextAdventureUploader->uploadsDirectroyPath()`
    
    commit c65065e3657cd4f2badc5b403013344426fb26fe
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sat Apr 23 17:39:49 2022 -0400
    
        Working on TextAdventureImporter. Preparing first test, .
    
    commit 32dc502e7a0807b8514b10a2c99a7c8f5fc8de1a
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sat Apr 23 17:00:37 2022 -0400
    
        Working on TextAdventureImporter, prepared for development of Apps\TextAdventureImporter\resources\classes\utility\TextAdventureUploader.php
    
    commit 025374bbd85331dc5c30fd9ad0920847a18832ae
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sat Apr 23 14:40:29 2022 -0400
    
        Working on TextAdventureImporter
    
    commit 9ac55b3908bc1f710747ac68558690c6d42372c7
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Sat Apr 23 02:17:12 2022 -0400
    
        Working on TextAdventureImporter
    
    commit e0e01be1ee1b8a2d283e51962c34c30e0c2eeb07
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Fri Apr 22 14:27:31 2022 -0400
    
        Working on TextAdventureImporter
    
    commit 49f352bdda58b99fc87f2a10a4a78b932937af9a
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Fri Apr 22 14:27:02 2022 -0400
    
        Working on TextAdventureImporter
    
    commit 69b9b361a6f2c6c08a67b0949645868519eaf5a5
    Author: sevidmusic <sevidmusic@gmail.com>
    Date:   Fri Apr 22 13:38:14 2022 -0400
    
        Working on TextAdventureImporter, added roady css classes to appropriate html elements. The uploads directory is now created if it does not exist on upload

commit 69a22a0de667e3d10512e3f3268070fcdd9aa82e
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Mon Apr 25 01:18:50 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented the following new tests in
    `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
    - `testFileToUploadSizeExceedsAllowedFileSizeReturnsFalseIfSizeOfFileToUploadDoesNotExceedAllowedFileSizeOf_5000000_bytes()`
    -
    `testFileToUploadSizeExceedsAllowedFileSizeReturnsTrueIfSizeOfFileToUploadExceedsAllowedFileSizeOf_5000000_bytes()`
    
    Implemented new method `fileToUploadSizeExceedsAllowedFileSize()` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    
    Code clean up in files mentioned above, and also in
    `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`

commit d9fa99048d1c305747c126da4d9b3edb0ed2b8d1
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun Apr 24 13:56:48 2022 -0400

    Working on TextAdventureImporter.
    
    Refactored TextAdventureUploader to expect an instance of a
    Request be passed to it's `__construct()` method in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    
    Implemented the following new test methods in
    `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:
    
    - `testFileToUploadIsAnHtmlFileReturnsTrueIfFileSelcetedForUploadHasTheExtension_html()`
    - `testCurrentRequestReturnsARequestInstanceWhosePostDataMatchesTheCurrentRequestsPostData()`
    - `testCurrentRequestReturnsARequestInstanceWhoseGetDataMatchesTheCurrentRequestsGetData()`
    
    Code clean up in TextAdventureImporter/DynamicOutput/TextAdventureImporter.php

commit df38185b7c073b8db3146938d7a0d24f3004b69c
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun Apr 24 12:19:21 2022 -0400

    Working on TextAdventureImporter.
    
    Cleaned up `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`