### PR TITLE
Working on TextAdventureImporter

### DIFF
--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -51,102 +51,98 @@ $failedToUploadFileMessage = "
     <p class=\"roady-error-message\">
         Sorry, there was an error uploading your file.
     </p>";
-if(
-    $textAdventureUploader->previousRequest()->getUniqueId()
-    ===
-    $textAdventureUploader->postRequestId()
+
+if (
+    $textAdventureUploader->uploadIsPossible()
 ) {
-    if (
-        $textAdventureUploader->uploadIsPossible()
+    $textAdventureUploader->upload();
+    $uploadWasSuccessful = move_uploaded_file(
+        $textAdventureUploader->fileToUploadsTemporaryName(),
+        $textAdventureUploader->pathToUploadFileTo()
+    );
+    echo match(
+       $uploadWasSuccessful
     ) {
-        $textAdventureUploader->upload();
-        $uploadWasSuccessful = move_uploaded_file(
-            $textAdventureUploader->fileToUploadsTemporaryName(),
-            $textAdventureUploader->pathToUploadFileTo()
-        );
-        echo match(
-           $uploadWasSuccessful
-        ) {
-            true => $fileUploadedSuccessfullyMessage,
-            default => $failedToUploadFileMessage,
-        };
-        if($uploadWasSuccessful) {
+        true => $fileUploadedSuccessfullyMessage,
+        default => $failedToUploadFileMessage,
+    };
+    if($uploadWasSuccessful) {
+        try {
+            $componentName = strval(
+                preg_replace(
+                    "/[^A-Za-z0-9 ]/",
+                    '',
+                    str_replace('.html', '', $textAdventureUploader->nameOfFileToUpload())
+                )
+            );
+            echo '<div class="roady-generic-container">';
+            echo '<pre class="roady-multi-line-code-container">';
+            echo '<code class="roady-multi-line-code">';
+            $configureAppOutput->run(
+                new CommandLineUI(),
+                $configureAppOutput->prepareArguments(
+                    [
+                        '--for-app',
+                        $componentName,
+                        '--name',
+                        $componentName,
+                        '--output',
+                        strval(
+                            file_get_contents(
+                                $textAdventureUploader->pathToUploadFileTo()
+                            )
+                        ),
+                    ]
+                )
+            );
+            echo '</code>';
+            echo '</pre>';
+            echo '</div>';
+            $pathToAppsComponentsPhp = strval(
+                str_replace(
+                    'TextAdventureImporter' .
+                    DIRECTORY_SEPARATOR .
+                    'DynamicOutput',
+                    $componentName .
+                    DIRECTORY_SEPARATOR .
+                    'Components.php',
+                    strval(realpath(__DIR__))
+                )
+            );
+            $scheme = parse_url(
+                $currentRequest->getUrl(),
+                PHP_URL_SCHEME
+            );
+            $host = parse_url(
+                $currentRequest->getUrl(),
+                PHP_URL_HOST
+            );
+            $port =  parse_url(
+                $currentRequest->getUrl(),
+                PHP_URL_PORT
+            );
+            $rootUrl =
+                $scheme . '://' . $host .
+                (empty($port) ? '' : ':' . $port);
+            var_dump($rootUrl);
             try {
-                $componentName = strval(
-                    preg_replace(
-                        "/[^A-Za-z0-9 ]/",
-                        '',
-                        str_replace('.html', '', $textAdventureUploader->nameOfFileToUpload())
-                    )
+                exec(
+                    PHP_BINARY .
+                    ' ' .
+                    escapeshellarg($pathToAppsComponentsPhp) .
+                    " '" . $rootUrl . "'"
                 );
-                echo '<div class="roady-generic-container">';
-                echo '<pre class="roady-multi-line-code-container">';
-                echo '<code class="roady-multi-line-code">';
-                $configureAppOutput->run(
-                    new CommandLineUI(),
-                    $configureAppOutput->prepareArguments(
-                        [
-                            '--for-app',
-                            $componentName,
-                            '--name',
-                            $componentName,
-                            '--output',
-                            strval(
-                                file_get_contents(
-                                    $textAdventureUploader->pathToUploadFileTo()
-                                )
-                            ),
-                        ]
-                    )
-                );
-                echo '</code>';
-                echo '</pre>';
-                echo '</div>';
-                $pathToAppsComponentsPhp = strval(
-                    str_replace(
-                        'TextAdventureImporter' .
-                        DIRECTORY_SEPARATOR .
-                        'DynamicOutput',
-                        $componentName .
-                        DIRECTORY_SEPARATOR .
-                        'Components.php',
-                        strval(realpath(__DIR__))
-                    )
-                );
-                $host = parse_url(
-                    $currentRequest->getUrl(),
-                    PHP_URL_HOST
-                );
-                $port =  parse_url(
-                    $currentRequest->getUrl(),
-                    PHP_URL_PORT
-                );
-                $rootUrl = 'https://' . $host . $port;
-                var_dump($rootUrl);
-                try {
-                    exec(
-                        PHP_BINARY .
-                        ' ' .
-                        escapeshellarg($pathToAppsComponentsPhp) .
-                        " '" . $rootUrl . "'"
-                    );
-                } catch (\RuntimeException $error) {
-                    echo '<p class="roady-error-message">Failed to build new App</p>';
-                }
             } catch (\RuntimeException $error) {
-                echo '<p class="roady-error-message">An error occurred, ConfigureAppOutput failed</p>';
-                echo '<p class="roady-error-message">Error: ' . $error->getMessage() . '</p>';
+                echo '<p class="roady-error-message">Failed to build new App</p>';
             }
+        } catch (\RuntimeException $error) {
+            echo '<p class="roady-error-message">An error occurred, ConfigureAppOutput failed</p>';
+            echo '<p class="roady-error-message">Error: ' . $error->getMessage() . '</p>';
         }
     }
 }
 ?>
 
-<?php
-
-
-
-?>
 <form
     class="roady-form"
     action="index.php?request=TextAdventureImporter"

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -18,6 +18,21 @@ $currentRequest = new Request(
     ),
     new Switchable()
 );
+$scheme = parse_url(
+    $currentRequest->getUrl(),
+    PHP_URL_SCHEME
+);
+$host = parse_url(
+    $currentRequest->getUrl(),
+    PHP_URL_HOST
+);
+$port =  parse_url(
+    $currentRequest->getUrl(),
+    PHP_URL_PORT
+);
+$rootUrl =
+    $scheme . '://' . $host .
+    (empty($port) ? '' : ':' . $port);
 $textAdventureUploader = new TextAdventureUploader(
     $currentRequest,
     new ComponentCrud(
@@ -109,22 +124,6 @@ if (
                     strval(realpath(__DIR__))
                 )
             );
-            $scheme = parse_url(
-                $currentRequest->getUrl(),
-                PHP_URL_SCHEME
-            );
-            $host = parse_url(
-                $currentRequest->getUrl(),
-                PHP_URL_HOST
-            );
-            $port =  parse_url(
-                $currentRequest->getUrl(),
-                PHP_URL_PORT
-            );
-            $rootUrl =
-                $scheme . '://' . $host .
-                (empty($port) ? '' : ':' . $port);
-            var_dump($rootUrl);
             try {
                 exec(
                     PHP_BINARY .
@@ -132,6 +131,19 @@ if (
                     escapeshellarg($pathToAppsComponentsPhp) .
                     " '" . $rootUrl . "'"
                 );
+                $appUrl = $rootUrl  .
+                    '?request=' .
+                    str_replace(
+                        '.html',
+                        '',
+                        $textAdventureUploader->nameOfFileToUpload()
+                    );
+                echo '<p class="roady-success-message">The ' .
+                    $textAdventureUploader->nameOfFileToUpload() .
+                    ' file was uploaded successfully, and has been ' .
+                    'converted into a roady App which can be ' .
+                    'accessed at the following url: ' .
+                    '<a href="' . $appUrl . '">' . $appUrl . '</a></p>';
             } catch (\RuntimeException $error) {
                 echo '<p class="roady-error-message">Failed to build new App</p>';
             }

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -215,6 +215,12 @@ class TextAdventureUploader {
             &&
             !$this->fileToUploadSizeExceedsAllowedFileSize()
             &&
+            (
+                $this->previousRequest()->getUniqueId()
+                ===
+                $this->postRequestId()
+            )
+            &&
             $this->safeToReplaceExistingGame();
     }
 }

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -185,7 +185,6 @@ class TextAdventureUploader {
         return false;
     }
 
-
     private function safeToReplaceExistingGame(): bool
     {
         return match(
@@ -206,6 +205,11 @@ class TextAdventureUploader {
              */
             default => true,
         };
+    }
+
+    public function aFileWasSelectedForUpload(): bool
+    {
+        return $this->nameOfFileToUpload() !== self::NO_FILE_SELECTED;
     }
 
     public function uploadIsPossible(): bool

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -71,6 +71,11 @@ class TextAdventureUploaderTest extends TestCase
         );
     }
 
+    /**
+     * @todo Consider instead using sha1_file() to generate
+     * a hash of the file to use as the uploaded files
+     * name. It would be safer than using a predictable name.
+     */
     public function testPathToUploadFileToReturnsTheNameOfFileToUploadPrefixedByThePathToUploadsDirectory(): void
     {
         $request = $this->mockCurrentRequest();
@@ -855,6 +860,50 @@ class TextAdventureUploaderTest extends TestCase
                 'match the postRequestId set in $_POST'
             );
         }
+    }
+
+    public function testAFileWasSelectedReturnsFalseIfAFileWasNotSeletedForUpload(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $testFileName = $request->getUniqueId() . '.html';
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $this->assertFalse(
+            $textAdventureUploader->aFileWasSelectedForUpload(),
+            TextAdventureUploader::class .
+            '->aFileWasSelectedForUpload() must return `false` if ' .
+            'a file was not selected for upload.'
+        );
+    }
+
+    public function testAFileWasSelectedReturnsTrueIfAFileWasSeletedForUpload(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $testFileName = $request->getUniqueId() . '.html';
+        $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILENAME_INDEX]
+            = $testFileName;
+        $request->import(
+            [
+                'post' => [
+                    TextAdventureUploader::POST_REQUEST_ID_INDEX
+                    => $request->getUniqueId()
+                ]
+            ]
+        );
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $this->assertTrue(
+            $textAdventureUploader->aFileWasSelectedForUpload(),
+            TextAdventureUploader::class .
+            '->aFileWasSelectedForUpload() must return `true` if ' .
+            'a file was selected for upload.'
+        );
     }
 }
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -671,7 +671,9 @@ class TextAdventureUploaderTest extends TestCase
             [
                 'post' => [
                     TextAdventureUploader::REPLACE_EXISTING_GAME_INDEX
-                    => 'true'
+                    => 'true',
+                    TextAdventureUploader::POST_REQUEST_ID_INDEX
+                    => $request->getUniqueId()
                 ]
             ]
         );
@@ -801,6 +803,56 @@ class TextAdventureUploaderTest extends TestCase
                 '->postRequestId() does not match the ' .
                 'the previous ' . Request::class . '\'s ' .
                 'unique id.'
+            );
+        }
+    }
+
+    public function testUploadIsPossibleReturnsFalseIfPostRequestIdDoesNotMatchPreviousRequestId(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $testFileName = $request->getUniqueId() . '.html';
+        $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILENAME_INDEX]
+            = $testFileName;
+        $request->import(
+            [
+                'post' => [
+                    TextAdventureUploader::REPLACE_EXISTING_GAME_INDEX
+                    => 'true',
+                    TextAdventureUploader::POST_REQUEST_ID_INDEX
+                    => $request->getUniqueId()
+                ]
+            ]
+        );
+        /**
+         * Instantiate initial instance to set previous
+         * Request.
+         */
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        /**
+         * Instantiate a second instance to invalidate
+         * previous Request.
+         */
+        $textAdventureUploader = new TextAdventureUploader(
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
+        );
+        if(
+            $textAdventureUploader->previousRequest()->getUniqueId()
+            !==
+            $textAdventureUploader->postRequestId()
+        ) {
+            $this->assertFalse(
+                $textAdventureUploader->uploadIsPossible(),
+                TextAdventureUploader::class .
+                '->uploadIsPossible()' .
+                'must return false if the ' .
+                'previous Request\'s id does not' .
+                'match the postRequestId set in $_POST'
             );
         }
     }


### PR DESCRIPTION
Implemented the following new test methods in
`TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:

- `testAFileWasSelectedReturnsFalseIfAFileWasNotSeletedForUpload`
- `testAFileWasSelectedReturnsTrueIfAFileWasSeletedForUpload()`
- `testUploadIsPossibleReturnsFalseIfPostRequestIdDoesNotMatchPreviousRequestId()`

Implemented new method `aFileWasSelectedForUpload()` in
`TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.

Refactored `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`:
- Now the root url is properly derived from current Request.
- A link is now displayed for the new App if upload and conversion
  were successful.
- Code clean up.
- No longer checking that previous `Request`'s `id` matches `postRequestId`,
  the `TextAdventureUploader->uploadIsPossible()` method now handles this check.