### PR TITLE
Working on TextAdventureImporter

### DIFF
--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -153,6 +153,12 @@ if (
         }
     }
 }
+
+if($textAdventureUploader->postRequestId() === $textAdventureUploader->previousRequest()->getUniqueId()) {
+    foreach($textAdventureUploader->errorMessages() as $errorMessage) {
+        echo '<p class="roady-error-message">' . $errorMessage . '</p>';
+    }
+}
 ?>
 
 <form

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -18,21 +18,6 @@ $currentRequest = new Request(
     ),
     new Switchable()
 );
-$scheme = parse_url(
-    $currentRequest->getUrl(),
-    PHP_URL_SCHEME
-);
-$host = parse_url(
-    $currentRequest->getUrl(),
-    PHP_URL_HOST
-);
-$port =  parse_url(
-    $currentRequest->getUrl(),
-    PHP_URL_PORT
-);
-$rootUrl =
-    $scheme . '://' . $host .
-    (empty($port) ? '' : ':' . $port);
 $textAdventureUploader = new TextAdventureUploader(
     $currentRequest,
     new ComponentCrud(
@@ -129,9 +114,9 @@ if (
                     PHP_BINARY .
                     ' ' .
                     escapeshellarg($pathToAppsComponentsPhp) .
-                    " '" . $rootUrl . "'"
+                    " '" . $textAdventureUploader->rootUrl() . "'"
                 );
-                $appUrl = $rootUrl  .
+                $appUrl = $textAdventureUploader->rootUrl()  .
                     '?request=' .
                     str_replace(
                         '.html',

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -35,7 +35,16 @@ class TextAdventureUploader {
 
     public const TEMPORARY_FILENAME_INDEX = 'tmp_name';
 
+    public const A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE =
+        'A Twine html file was not selected. Please select a Twine ' .
+        'html file to upload!';
+
     private Request $previousRequest;
+
+    /**
+     * @var array<int, string> $errorMessages
+     */
+    private array $errorMessages = [];
 
     public function __construct(
         private Request $currentRequest,
@@ -207,9 +216,24 @@ class TextAdventureUploader {
         };
     }
 
+    /**
+     * @return array<int, string>
+     */
+    public function errorMessages(): array
+    {
+        return $this->errorMessages;
+    }
+
     public function aFileWasSelectedForUpload(): bool
     {
-        return $this->nameOfFileToUpload() !== self::NO_FILE_SELECTED;
+        if($this->nameOfFileToUpload() === self::NO_FILE_SELECTED) {
+            array_push(
+                $this->errorMessages,
+                self::A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE,
+            );
+            return false;
+        }
+        return true;
     }
 
     public function uploadIsPossible(): bool

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -253,5 +253,44 @@ class TextAdventureUploader {
             &&
             $this->safeToReplaceExistingGame();
     }
+
+    public function rootUrl(): string
+    {
+        return
+            $this->rootUrlScheme() .
+            $this->rootUrlHost() .
+            $this->rootUrlPort();
+    }
+
+    private function rootUrlHost(): string
+    {
+        return strval(
+            parse_url(
+                $this->currentRequest()->getUrl(),
+                PHP_URL_HOST
+            )
+        );
+    }
+
+    private function rootUrlScheme(): string
+    {
+        return strval(
+            parse_url(
+                $this->currentRequest()->getUrl(),
+                PHP_URL_SCHEME
+            )
+        ) . '://';
+    }
+
+    private function rootUrlPort(): string
+    {
+        $port =  strval(
+            parse_url(
+                $this->currentRequest()->getUrl(),
+                PHP_URL_PORT
+            )
+        );
+        return (empty($port) ? '' : ':' . $port);
+    }
 }
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -865,7 +865,6 @@ class TextAdventureUploaderTest extends TestCase
     public function testAFileWasSelectedReturnsFalseIfAFileWasNotSeletedForUpload(): void
     {
         $request = $this->mockCurrentRequest();
-        $testFileName = $request->getUniqueId() . '.html';
         $textAdventureUploader = new TextAdventureUploader(
             $request,
             $this->mockComponentCrud()
@@ -966,14 +965,48 @@ class TextAdventureUploaderTest extends TestCase
             );
         }
     }
+
+    public function test_A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE_IsAssignedTheAppropriateErrorMessage(): void
+    {
+        $expectedErrorMessage = 'A Twine html file was not ' .
+           'selected. Please select a Twine html file to upload!';
+        $this->assertEquals(
+            $expectedErrorMessage,
+            TextAdventureUploader::A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE,
+            TextAdventureUploader::class .
+            '::A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE ' .
+            'must be assigned the string: ' .
+            $expectedErrorMessage
+        );
+    }
+
+    public function testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingAFileWasNotSelectedForUploadIfAFileWasSelectedForUploadReturnsFalse(): void
+    {
+        $textAdventureUploader = new TextAdventureUploader(
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
+        );
+        $textAdventureUploader->aFileWasSelectedForUpload();
+        $this->assertTrue(
+            in_array(
+                TextAdventureUploader::A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE,
+                $textAdventureUploader->errorMessages(),
+            ),
+            TextAdventureUploader::class .
+            '->errorMessages() must return an array that ' .
+            'includes an error message that indicates a ' .
+            'file was not selected for upload if ' .
+            TextAdventureUploader::class .
+            '->aFileWasSelectedForUpload() returns `false`'
+        );
+    }
 }
 
 /**
  *
 $aFileWasNotSelectedMessage = '
     <p class="roady-error-message">
-        A Twine html file was not selected.
-        Please select a Twine html file to upload!
+
     </p>
 ';
 $invalidFileTypeMessage = '

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -1000,15 +1000,31 @@ class TextAdventureUploaderTest extends TestCase
             '->aFileWasSelectedForUpload() returns `false`'
         );
     }
+
+    public function testRootUrlReturnsRootUrlDerivedFromSpecifiedRequest(): void
+    {
+        $request = $this->mockCurrentRequest();
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $scheme = parse_url(
+            $request->getUrl(),
+            PHP_URL_SCHEME
+        );
+        $host = parse_url($request->getUrl(), PHP_URL_HOST);
+        $port =  parse_url($request->getUrl(), PHP_URL_PORT);
+        $expectedRootUrl = $scheme . '://' . $host .
+            (empty($port) ? '' : ':' . $port);
+        $this->assertEquals(
+            $expectedRootUrl,
+            $textAdventureUploader->rootUrl(),
+        );
+    }
 }
 
 /**
  *
-$aFileWasNotSelectedMessage = '
-    <p class="roady-error-message">
-
-    </p>
-';
 $invalidFileTypeMessage = '
     <p class="roady-error-message">
         Only Twine html files can be uploaded!


### PR DESCRIPTION
commit e41885143ceeeafb4742bfe26163361aeed6e94b (HEAD -> roadyAppPackages1652284083, origin/roadyAppPackages1652284083)
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Fri May 13 00:44:18 2022 -0400

    Working on TextAdventureImporter.

    Implemented new test method
    `testRootUrlReturnsRootUrlDerivedFromSpecifiedRequest()`
    in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`

    Implemented new method `rootUrl()` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`

    Refactored `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    to utilize new `TextAdventureUploader->rootUrl()` method where
    appropriate.

commit 8d9947cc585e51e9bf72edd17d427ce3b6ba78fb
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Thu May 12 00:55:35 2022 -0400

    Working on TextAdventureImporter.

    Implemented the following new test methods in
    `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`

    - `test_A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE_IsAssignedTheAppropriateErrorMessage()`
    - `testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingAFileWasNotSelectedForUploadIfAFileWasSelectedForUploadReturnsFalse()`

    Refactored `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`:

    - `aFileWasSelectedForUpload()` method now adds the
       `TextAdventureUploader::A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE`
       to the `TextAdventureUploader->errorMessages` array if a file was
       not selected for upload.
    - Defined new constant `A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE`

    Refactored `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`
    to display any errors that may have occurred.