### PR TITLE
Working on TextAdventureImporter.

### DIFF
--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -39,6 +39,10 @@ class TextAdventureUploader {
         'A Twine html file was not selected. Please select a Twine ' .
         'html file to upload!';
 
+    public const SELECTED_FILE_IS_NOT_AN_HTML_FILE_ERROR_MESSAGE =
+        'The selected file is not a valid ' .
+        ' html file. Only html files may be uploaded.';
+
     private Request $previousRequest;
 
     /**
@@ -125,12 +129,20 @@ class TextAdventureUploader {
     {
         // @todo Refactor to more securely verify file is an html file
         // @see https://www.php.net/manual/en/features.file-upload.php
-        return strtolower(
+        $fileToUploadIsAnHtmlFile = strtolower(
             pathinfo(
                 $this->nameOfFileToUpload(),
                 PATHINFO_EXTENSION
             )
         ) === 'html';
+        if($fileToUploadIsAnHtmlFile) {
+            return true;
+        }
+        array_push(
+            $this->errorMessages,
+            self::SELECTED_FILE_IS_NOT_AN_HTML_FILE_ERROR_MESSAGE,
+        );
+        return false;
     }
 
     public function currentRequest(): Request

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -1001,6 +1001,41 @@ class TextAdventureUploaderTest extends TestCase
         );
     }
 
+    public function test_SELECTED_FILE_IS_NOT_AN_HTML_FILE_ERROR_MESSAGE_IsAssignedTheAppropriateErrorMessage(): void
+    {
+        $expectedErrorMessage = 'The selected file is not a valid ' .
+           ' html file. Only html files may be uploaded.';
+        $this->assertEquals(
+            $expectedErrorMessage,
+            TextAdventureUploader::SELECTED_FILE_IS_NOT_AN_HTML_FILE_ERROR_MESSAGE,
+            TextAdventureUploader::class .
+            '::SELECTED_FILE_IS_NOT_AN_HTML_FILE_ERROR_MESSAGE ' .
+            'must be assigned the string: ' .
+            $expectedErrorMessage
+        );
+    }
+
+    public function testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingATheSlectedFileIsNotAnHtmlFileIfFileToUploadIsAnHtmlFileReturnsFalse(): void
+    {
+        $textAdventureUploader = new TextAdventureUploader(
+            $this->mockCurrentRequest(),
+            $this->mockComponentCrud()
+        );
+        $textAdventureUploader->fileToUploadIsAnHtmlFile();
+        $this->assertTrue(
+            in_array(
+                TextAdventureUploader::SELECTED_FILE_IS_NOT_AN_HTML_FILE_ERROR_MESSAGE,
+                $textAdventureUploader->errorMessages(),
+            ),
+            TextAdventureUploader::class .
+            '->errorMessages() must return an array that ' .
+            'includes an error message that indicates a ' .
+            'the selected file is not an html file if ' .
+            TextAdventureUploader::class .
+            '->fileToUploadIsAnHtmlFile() returns `false`'
+        );
+    }
+
     public function testRootUrlReturnsRootUrlDerivedFromSpecifiedRequest(): void
     {
         $request = $this->mockCurrentRequest();


### PR DESCRIPTION
Implemented the following new test methods
in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:

- `test_SELECTED_FILE_IS_NOT_AN_HTML_FILE_ERROR_MESSAGE_IsAssignedTheAppropriateErrorMessage()`
- `testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingATheSlectedFileIsNotAnHtmlFileIfFileToUploadIsAnHtmlFileReturnsFalse()`

Defined new constant `SELECTED_FILE_IS_NOT_AN_HTML_FILE_ERROR_MESSAGE`
in `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.
Also, refactored the `fileToUploadIsAnHtmlFile()`
method to add the `SELECTED_FILE_IS_NOT_AN_HTML_FILE_ERROR_MESSAGE`
to the error messages array if the selected file is not an html file.