### PR TITLE
Working on TextAdventureImporter

### DIFF
--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -55,6 +55,17 @@ $failedToUploadFileMessage = "
 if (
     $textAdventureUploader->uploadIsPossible()
 ) {
+
+// DEV
+    // @todo TextAdventureUploader->uploadIsPossible() must
+    // also perform the following checks
+if(
+    is_array($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error'])
+) {
+    throw new RuntimeException('Bad Upload Request');
+}
+
+// END DEV
     $textAdventureUploader->upload();
     $uploadWasSuccessful = move_uploaded_file(
         $textAdventureUploader->fileToUploadsTemporaryName(),

--- a/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
+++ b/TextAdventureImporter/DynamicOutput/TextAdventureImporter.php
@@ -55,17 +55,6 @@ $failedToUploadFileMessage = "
 if (
     $textAdventureUploader->uploadIsPossible()
 ) {
-
-// DEV
-    // @todo TextAdventureUploader->uploadIsPossible() must
-    // also perform the following checks
-if(
-    is_array($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error'])
-) {
-    throw new RuntimeException('Bad Upload Request');
-}
-
-// END DEV
     $textAdventureUploader->upload();
     $uploadWasSuccessful = move_uploaded_file(
         $textAdventureUploader->fileToUploadsTemporaryName(),

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -160,13 +160,22 @@ class TextAdventureUploader {
     public function fileToUploadSizeExceedsAllowedFileSize(): bool
     {
         // @todo Refactor to more accurately check file size
-        return (
-            $_FILES
-            [self::FILE_TO_UPLOAD_INDEX]
-            [TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX]
-            ??
-            self::MAXIMUM_ALLOWED_FILE_SIZE
-        ) > self::MAXIMUM_ALLOWED_FILE_SIZE;
+        if (
+            (
+                $_FILES
+                [self::FILE_TO_UPLOAD_INDEX]
+                [TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX]
+                ??
+                self::MAXIMUM_ALLOWED_FILE_SIZE
+            ) > self::MAXIMUM_ALLOWED_FILE_SIZE
+        ) {
+            array_push(
+                $this->errorMessages,
+                self::FILE_TO_UPLOAD_SIZE_EXCEEDS_ALLOWED_FILE_SIZE_ERROR_MESSAGE,
+            );
+            return true;
+        }
+        return false;
 
     }
 

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -283,6 +283,8 @@ class TextAdventureUploader {
     public function uploadIsPossible(): bool
     {
         return
+            isset($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error'])
+            &&
             $this->aFileWasSelectedForUpload()
             &&
             $this->fileToUploadIsAnHtmlFile()

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -47,7 +47,7 @@ class TextAdventureUploader {
 
     public const FILE_TO_UPLOAD_SIZE_EXCEEDS_ALLOWED_FILE_SIZE_ERROR_MESSAGE =
         'The selected file is too large! Please choose a file ' .
-        'that is less than 5 megabytes.';
+        'that is less than 1 megabytes.';
 
     private Request $previousRequest;
 

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -272,7 +272,13 @@ class TextAdventureUploader {
 
     public function aFileWasSelectedForUpload(): bool
     {
-        if($this->nameOfFileToUpload() === self::NO_FILE_SELECTED) {
+        if(
+            (
+                $this->nameOfFileToUpload()
+                ===
+                self::NO_FILE_SELECTED
+            )
+        ) {
             array_push(
                 $this->errorMessages,
                 self::A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE,
@@ -282,24 +288,45 @@ class TextAdventureUploader {
         return true;
     }
 
+    private function uploadRequestIsValid(): bool
+    {
+        return (
+            $this->previousRequest()->getUniqueId()
+            ===
+            $this->postRequestId()
+            &&
+            isset(
+                $_FILES
+                [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+                [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]
+            )
+            &&
+            !is_array(
+                $_FILES
+                [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+                [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]
+            )
+            &&
+            (
+                $_FILES
+                [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+                [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]
+                ===
+                UPLOAD_ERR_OK
+            )
+        );
+    }
+
     public function uploadIsPossible(): bool
     {
         return
-            isset($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error'])
-            &&
-            !is_array($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error'])
-            &&
             $this->aFileWasSelectedForUpload()
+            &&
+            $this->uploadRequestIsValid()
             &&
             $this->fileToUploadIsAnHtmlFile()
             &&
             !$this->fileToUploadSizeExceedsAllowedFileSize()
-            &&
-            (
-                $this->previousRequest()->getUniqueId()
-                ===
-                $this->postRequestId()
-            )
             &&
             $this->safeToReplaceExistingGame();
     }

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -10,6 +10,8 @@ use roady\classes\primary\Switchable;
 
 class TextAdventureUploader {
 
+    public const FILE_UPLOAD_ERRORS_INDEX = 'error';
+
     public const NO_FILE_SELECTED = 'NO_FILE_SELECTED';
 
     private const RELATIVE_PATH_TO_UPLOADS_DIRECTORY =

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -49,6 +49,12 @@ class TextAdventureUploader {
         'The selected file is too large! Please choose a file ' .
         'that is less than 1 megabytes.';
 
+    public const FILE_WAS_ALREADY_UPLOADED_AND_REQUEST_DID_NOT_INDICATE_EXISTING_FILE_SHOULD_BE_REPLACE_ERROR_MESSAGE =
+        'A file already exists whose name ' .
+        'matches the name of the specified file\'s name. ' .
+        'Please select a file with a different name, or check ' .
+        'the  "Replace Existing" box.';
+
     private Request $previousRequest;
 
     /**

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -35,6 +35,8 @@ class TextAdventureUploader {
 
     public const TEMPORARY_FILENAME_INDEX = 'tmp_name';
 
+    public const MAXIMUM_ALLOWED_FILE_SIZE = 1000000;
+
     public const A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE =
         'A Twine html file was not selected. Please select a Twine ' .
         'html file to upload!';
@@ -158,14 +160,13 @@ class TextAdventureUploader {
     public function fileToUploadSizeExceedsAllowedFileSize(): bool
     {
         // @todo Refactor to more accurately check file size
-        $maximumAllowedFileSizeInBytes = 5000000;
         return (
             $_FILES
             [self::FILE_TO_UPLOAD_INDEX]
             [TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX]
             ??
-            $maximumAllowedFileSizeInBytes
-        ) > $maximumAllowedFileSizeInBytes;
+            self::MAXIMUM_ALLOWED_FILE_SIZE
+        ) > self::MAXIMUM_ALLOWED_FILE_SIZE;
 
     }
 

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -278,6 +278,18 @@ class TextAdventureUploader {
                 ===
                 self::NO_FILE_SELECTED
             )
+            ||
+            (
+                (
+                    $_FILES
+                    [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+                    [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]
+                    ??
+                    ''
+                )
+                ===
+                UPLOAD_ERR_NO_FILE
+            )
         ) {
             array_push(
                 $this->errorMessages,

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -43,6 +43,10 @@ class TextAdventureUploader {
         'The selected file is not a valid ' .
         ' html file. Only html files may be uploaded.';
 
+    public const FILE_TO_UPLOAD_SIZE_EXCEEDS_ALLOWED_FILE_SIZE_ERROR_MESSAGE =
+        'The selected file is too large! Please choose a file ' .
+        'that is less than 5 megabytes.';
+
     private Request $previousRequest;
 
     /**
@@ -154,9 +158,14 @@ class TextAdventureUploader {
     public function fileToUploadSizeExceedsAllowedFileSize(): bool
     {
         // @todo Refactor to more accurately check file size
+        $maximumAllowedFileSizeInBytes = 5000000;
         return (
-            $_FILES[self::FILE_TO_UPLOAD_INDEX][TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX] ?? 5000000
-        ) > 5000000;
+            $_FILES
+            [self::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX]
+            ??
+            $maximumAllowedFileSizeInBytes
+        ) > $maximumAllowedFileSizeInBytes;
 
     }
 

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -285,6 +285,8 @@ class TextAdventureUploader {
         return
             isset($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error'])
             &&
+            !is_array($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error'])
+            &&
             $this->aFileWasSelectedForUpload()
             &&
             $this->fileToUploadIsAnHtmlFile()

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -51,7 +51,7 @@ class TextAdventureUploader {
 
     public const FILE_WAS_ALREADY_UPLOADED_AND_REQUEST_DID_NOT_INDICATE_EXISTING_FILE_SHOULD_BE_REPLACE_ERROR_MESSAGE =
         'A file already exists whose name ' .
-        'matches the name of the specified file\'s name. ' .
+        'matches the name of the specified file. ' .
         'Please select a file with a different name, or check ' .
         'the  "Replace Existing" box.';
 
@@ -202,7 +202,7 @@ class TextAdventureUploader {
 
     public function replaceExistingGame(): bool
     {
-        return (
+        if (
             (
                 $this->currentRequest()
                      ->getPost()[self::REPLACE_EXISTING_GAME_INDEX]
@@ -211,7 +211,14 @@ class TextAdventureUploader {
             )
             ===
             'true'
+        ) {
+            return true;
+        }
+        array_push(
+            $this->errorMessages,
+            self::FILE_WAS_ALREADY_UPLOADED_AND_REQUEST_DID_NOT_INDICATE_EXISTING_FILE_SHOULD_BE_REPLACE_ERROR_MESSAGE,
         );
+        return false;
     }
 
     public function fileToUploadsTemporaryName(): string

--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -112,7 +112,7 @@ class TextAdventureUploader {
             true =>
                 $this->pathToUploadsDirectory() .
                 DIRECTORY_SEPARATOR .
-                basename($this->nameOfFileToUpload()),
+                sha1(basename($this->nameOfFileToUpload())),
             default => $this->nameOfFileToUpload(),
         };
     }

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -122,17 +122,17 @@ class TextAdventureUploaderTest extends TestCase
     public function testNameOfFileToUploadRetunrsTheNameOfTheFileToUploadIfAFileHasBeenSelectedForUpload(): void
     {
         $request = $this->mockRequest();
-        $textAdventureUploader = new TextAdventureUploader(
-            $request,
-            $this->mockComponentCrud()
-        );
         $this->mockUploadRequest(
             $request,
             fileWasSelected: true,
             fileSizeIsValid: true,
             fileIsAnHtmlFile: true,
-            setReplaceExistingGame: true,
+            setReplaceExistingGame: false,
             setPostRequestId: true,
+        );
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
         );
         $this->assertEquals(
             $_FILES
@@ -150,17 +150,17 @@ class TextAdventureUploaderTest extends TestCase
     public function testPathToUploadFileToReturnsTheNameOfFileToUploadPrefixedByThePathToUploadsDirectory(): void
     {
         $request = $this->mockRequest();
-        $textAdventureUploader = new TextAdventureUploader(
-            $request,
-            $this->mockComponentCrud()
-        );
         $this->mockUploadRequest(
             $request,
             fileWasSelected: true,
             fileSizeIsValid: true,
             fileIsAnHtmlFile: true,
-            setReplaceExistingGame: true,
+            setReplaceExistingGame: false,
             setPostRequestId: true,
+        );
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
         );
         $this->assertEquals(
             $textAdventureUploader->pathToUploadsDirectory() .
@@ -215,7 +215,9 @@ class TextAdventureUploaderTest extends TestCase
     {
         $this->assertEquals(
             'size',
-            TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX
+            TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX,
+            'TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX constant must ' .
+            'be assigned the string `size`.'
         );
     }
 
@@ -223,23 +225,29 @@ class TextAdventureUploaderTest extends TestCase
     {
         $this->assertEquals(
             'fileToUpload',
-            TextAdventureUploader::FILE_TO_UPLOAD_INDEX
+            TextAdventureUploader::FILE_TO_UPLOAD_INDEX,
+            'TextAdventureUploader::FILE_TO_UPLOAD_INDEX constant must ' .
+            'be assigned the string `fileToUpload`.'
         );
     }
 
     public function testPOST_REQUEST_ID_INDEXConstantIsAssignedTheString_postRequestId(): void
     {
         $this->assertEquals(
+            'postRequestId',
             TextAdventureUploader::POST_REQUEST_ID_INDEX,
-            TextAdventureUploader::POST_REQUEST_ID_INDEX
+            'TextAdventureUploader::POST_REQUEST_ID_INDEX constant must ' .
+            'be assigned the string `postRequestId`.'
         );
     }
 
-    public function testREPLACE_EXISTING_GAMEConstantIsAssignedTheString_replaceExistingGame(): void
+    public function testREPLACE_EXISTING_GAME_INDEXConstantIsAssignedTheString_replaceExistingGame(): void
     {
         $this->assertEquals(
+            'replaceExistingGame',
             TextAdventureUploader::REPLACE_EXISTING_GAME_INDEX,
-            TextAdventureUploader::REPLACE_EXISTING_GAME_INDEX
+            'TextAdventureUploader::REPLACE_EXISTING_GAME_INDEX constant must ' .
+            'be assigned the string `replaceExistingGame`.'
         );
     }
 
@@ -275,8 +283,17 @@ class TextAdventureUploaderTest extends TestCase
 
     public function testFileToUploadIsAnHtmlFileReturnsFalseIfFileSelcetedForUploadDoesNotHaveTheExtension_html(): void
     {
+        $request = $this->mockRequest();
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: false,
+            setReplaceExistingGame: false,
+            setPostRequestId: true,
+        );
         $textAdventureUploader = new TextAdventureUploader(
-            $this->mockRequest(),
+            $request,
             $this->mockComponentCrud()
         );
         $this->assertFalse(
@@ -290,17 +307,17 @@ class TextAdventureUploaderTest extends TestCase
     public function testFileToUploadIsAnHtmlFileReturnsTrueIfFileSelcetedForUploadHasTheExtension_html(): void
     {
         $request = $this->mockRequest();
-        $textAdventureUploader = new TextAdventureUploader(
-            $request,
-            $this->mockComponentCrud()
-        );
         $this->mockUploadRequest(
             $request,
             fileWasSelected: true,
             fileSizeIsValid: true,
             fileIsAnHtmlFile: true,
-            setReplaceExistingGame: true,
+            setReplaceExistingGame: false,
             setPostRequestId: true,
+        );
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
         );
         $this->assertTrue(
             $textAdventureUploader->fileToUploadIsAnHtmlFile(),
@@ -393,7 +410,7 @@ class TextAdventureUploaderTest extends TestCase
             fileWasSelected: true,
             fileSizeIsValid: true,
             fileIsAnHtmlFile: true,
-            setReplaceExistingGame: true,
+            setReplaceExistingGame: false,
             setPostRequestId: true,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -419,7 +436,7 @@ class TextAdventureUploaderTest extends TestCase
             fileWasSelected: true,
             fileSizeIsValid: false,
             fileIsAnHtmlFile: true,
-            setReplaceExistingGame: true,
+            setReplaceExistingGame: false,
             setPostRequestId: true,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -688,7 +705,7 @@ class TextAdventureUploaderTest extends TestCase
             fileWasSelected: true,
             fileSizeIsValid: true,
             fileIsAnHtmlFile: true,
-            setReplaceExistingGame: true,
+            setReplaceExistingGame: false,
             setPostRequestId: true,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -820,7 +837,7 @@ class TextAdventureUploaderTest extends TestCase
             fileWasSelected: true,
             fileSizeIsValid: false,
             fileIsAnHtmlFile: true,
-            setReplaceExistingGame: true,
+            setReplaceExistingGame: false,
             setPostRequestId: true,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -850,7 +867,7 @@ class TextAdventureUploaderTest extends TestCase
             fileWasSelected: true,
             fileSizeIsValid: true,
             fileIsAnHtmlFile: false,
-            setReplaceExistingGame: true,
+            setReplaceExistingGame: false,
             setPostRequestId: true,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -984,7 +1001,7 @@ class TextAdventureUploaderTest extends TestCase
             fileWasSelected: true,
             fileSizeIsValid: true,
             fileIsAnHtmlFile: true,
-            setReplaceExistingGame: true,
+            setReplaceExistingGame: false,
             setPostRequestId: true,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -1024,7 +1041,7 @@ class TextAdventureUploaderTest extends TestCase
             fileWasSelected: true,
             fileSizeIsValid: true,
             fileIsAnHtmlFile: true,
-            setReplaceExistingGame: true,
+            setReplaceExistingGame: false,
             setPostRequestId: true,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -1076,19 +1093,20 @@ class TextAdventureUploaderTest extends TestCase
             $this->mockRequest(),
             $this->mockComponentCrud()
         );
-        $textAdventureUploader->aFileWasSelectedForUpload();
-        $this->assertTrue(
-            in_array(
-                TextAdventureUploader::A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE,
-                $textAdventureUploader->errorMessages(),
-            ),
-            TextAdventureUploader::class .
-            '->errorMessages() must return an array that ' .
-            'includes an error message that indicates a ' .
-            'file was not selected for upload if ' .
-            TextAdventureUploader::class .
-            '->aFileWasSelectedForUpload() returns `false`'
-        );
+        if(!$textAdventureUploader->aFileWasSelectedForUpload()) {
+            $this->assertTrue(
+                in_array(
+                    TextAdventureUploader::A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE,
+                    $textAdventureUploader->errorMessages(),
+                ),
+                TextAdventureUploader::class .
+                '->errorMessages() must return an array that ' .
+                'includes an error message that indicates a ' .
+                'file was not selected for upload if ' .
+                TextAdventureUploader::class .
+                '->aFileWasSelectedForUpload() returns `false`'
+            );
+        }
     }
 
     public function test_SELECTED_FILE_IS_NOT_AN_HTML_FILE_ERROR_MESSAGE_IsAssignedTheAppropriateErrorMessage(): void
@@ -1111,25 +1129,33 @@ class TextAdventureUploaderTest extends TestCase
             $this->mockRequest(),
             $this->mockComponentCrud()
         );
-        $textAdventureUploader->fileToUploadIsAnHtmlFile();
-        $this->assertTrue(
-            in_array(
-                TextAdventureUploader::SELECTED_FILE_IS_NOT_AN_HTML_FILE_ERROR_MESSAGE,
-                $textAdventureUploader->errorMessages(),
-            ),
-            TextAdventureUploader::class .
-            '->errorMessages() must return an array that ' .
-            'includes an error message that indicates a ' .
-            'the selected file is not an html file if ' .
-            TextAdventureUploader::class .
-            '->fileToUploadIsAnHtmlFile() returns `false`'
-        );
+        if(!$textAdventureUploader->fileToUploadIsAnHtmlFile()) {
+            $this->assertTrue(
+                in_array(
+                    TextAdventureUploader::SELECTED_FILE_IS_NOT_AN_HTML_FILE_ERROR_MESSAGE,
+                    $textAdventureUploader->errorMessages(),
+                ),
+                TextAdventureUploader::class .
+                '->errorMessages() must return an array that ' .
+                'includes an error message that indicates a ' .
+                'the selected file is not an html file if ' .
+                TextAdventureUploader::class .
+                '->fileToUploadIsAnHtmlFile() returns `false`'
+            );
+        }
     }
 
     public function test_FILE_TO_UPLOAD_SIZE_EXCEEDS_ALLOWED_FILE_SIZE_ERROR_MESSAGE_IsAssignedTheAppropriateErrorMessage(): void
     {
         $expectedErrorMessage = 'The selected file is too large! ' .
-            'Please choose a file that is less than 5 megabytes.';
+            'Please choose a file that is less than ' .
+            strval(
+                (
+                    TextAdventureUploader::MAXIMUM_ALLOWED_FILE_SIZE
+                    *
+                    0.000001
+                )
+            ) . ' megabytes.';
         $this->assertEquals(
             $expectedErrorMessage,
             TextAdventureUploader::FILE_TO_UPLOAD_SIZE_EXCEEDS_ALLOWED_FILE_SIZE_ERROR_MESSAGE,
@@ -1175,10 +1201,6 @@ class TextAdventureUploaderTest extends TestCase
 
 /**
  *
-$fileIsToLargeMessage = '
-    <p class="roady-error-message">
-    </p>
-';
 
 $theSpecifiedTwineFileWasAlreadyImportedMessage = "
     <div class=\"roady-error-message\">

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -192,7 +192,7 @@ class TextAdventureUploaderTest extends TestCase
         $this->assertEquals(
             $textAdventureUploader->pathToUploadsDirectory() .
             DIRECTORY_SEPARATOR .
-            $textAdventureUploader->nameOfFileToUpload(),
+            sha1(basename($textAdventureUploader->nameOfFileToUpload())),
             $textAdventureUploader->pathToUploadFileTo()
         );
     }
@@ -820,7 +820,7 @@ class TextAdventureUploaderTest extends TestCase
         $pathToTestFile =
             $textAdventureUploader->pathToUploadsDirectory() .
             DIRECTORY_SEPARATOR .
-            $testFileName;
+            sha1(basename($testFileName));
         if(
             !is_dir($textAdventureUploader->pathToUploadsDirectory())
         ) {
@@ -877,7 +877,7 @@ class TextAdventureUploaderTest extends TestCase
         $pathToTestFile =
             $textAdventureUploader->pathToUploadsDirectory() .
             DIRECTORY_SEPARATOR .
-            $testFileName;
+            sha1(basename($testFileName));
         if(
             !is_dir($textAdventureUploader->pathToUploadsDirectory())
         ) {
@@ -1373,7 +1373,7 @@ class TextAdventureUploaderTest extends TestCase
         $pathToTestFile =
             $textAdventureUploader->pathToUploadsDirectory() .
             DIRECTORY_SEPARATOR .
-            $testFileName;
+            sha1(basename($testFileName));
         if(
             !is_dir($textAdventureUploader->pathToUploadsDirectory())
         ) {

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -634,9 +634,18 @@ class TextAdventureUploaderTest extends TestCase
         );
     }
 
-    public function testReplaceExistingGameReturnsFalseIfValueSetInSpecifiedRequestsPOSTDataForReplaceExistingGameIsNotSetToTheString_true(): void
+    public function testReplaceExistingGameReturnsFalseIf_POST_REPLACE_EXISTING_GAME_INDEX_IsNotSetToTheString_true(): void
     {
+        // TextAdventureUploader::REPLACE_EXISTING_GAME_INDEX
         $request = $this->mockRequest();
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: false,
+            setPostRequestId: true,
+        );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
             $this->mockComponentCrud()
@@ -651,16 +660,16 @@ class TextAdventureUploaderTest extends TestCase
         );
     }
 
-    public function testReplaceExistingGameReturnsTrueIfValueSetInSpecifiedRequestsPOSTDataForReplaceExistingGameIsSetToTheString_true(): void
+    public function testReplaceExistingGameReturnsTrueIf_POST_REPLACE_EXISTING_GAME_INDEX_IsSetToTheString_true(): void
     {
         $request = $this->mockRequest();
-        $request->import(
-            [
-                'post' => [
-                    TextAdventureUploader::REPLACE_EXISTING_GAME_INDEX
-                    => 'true'
-                ]
-            ]
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: true,
+            setPostRequestId: true,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -1237,6 +1246,23 @@ class TextAdventureUploaderTest extends TestCase
             '::MAXIMUM_ALLOWED_FILE_SIZE must be assigned the ' .
             'integer ' .
             self::MAXIMUM_ALLOWED_FILE_SIZE
+        );
+    }
+
+    public function test_FILE_WAS_ALREADY_UPLOADED_AND_REQUEST_DID_NOT_INDICATE_EXISTING_FILE_SHOULD_BE_REPLACE_ERROR_MESSAGE_IsAssignedTheAppropriateErrorMessage(): void
+    {
+        // FILE_WAS_ALREADY_UPLOADED_AND_REQUEST_DID_NOT_INDICATE_EXISTING_FILE_SHOULD_BE_REPLACE_ERROR_MESSAGE
+        $expectedErrorMessage = 'A file already exists whose name ' .
+            'matches the name of the specified file\'s name. ' .
+            'Please select a file with a different name, or check ' .
+            'the  "Replace Existing" box.';
+        $this->assertEquals(
+            $expectedErrorMessage,
+            TextAdventureUploader::FILE_WAS_ALREADY_UPLOADED_AND_REQUEST_DID_NOT_INDICATE_EXISTING_FILE_SHOULD_BE_REPLACE_ERROR_MESSAGE,
+            TextAdventureUploader::class .
+            '::FILE_WAS_ALREADY_UPLOADED_AND_REQUEST_DID_NOT_INDICATE_EXISTING_FILE_SHOULD_BE_REPLACE_ERROR_MESSAGE ' .
+            'must be assigned the string: ' .
+            $expectedErrorMessage
         );
     }
 }

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -31,6 +31,11 @@ class TextAdventureUploaderTest extends TestCase
 
     }
 
+    /**
+     * For an overview of PHP's upload error message values:
+     *
+     * @see https://www.php.net/manual/en/features.file-upload.errors.php
+     */
     private function mockUploadRequest(
         Request $request,
         bool $fileWasSelected,
@@ -38,6 +43,8 @@ class TextAdventureUploaderTest extends TestCase
         bool $fileIsAnHtmlFile,
         bool $setReplaceExistingGame,
         bool $setPostRequestId,
+        bool $setFilesErrors,
+        int $filesErrorsValue,
     ): void
     {
         $request->import(
@@ -54,6 +61,11 @@ class TextAdventureUploaderTest extends TestCase
                 ]
             ]
         );
+        if($fileWasSelected && $setFilesErrors) {
+            $_FILES
+                [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+                ['error'] = $filesErrorsValue;
+        }
         $_FILES
             [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
             [TextAdventureUploader::FILENAME_INDEX]
@@ -112,6 +124,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: false,
             setReplaceExistingGame: false,
             setPostRequestId: false,
+            setFilesErrors: false,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $this->assertEquals(
              TextAdventureUploader::NO_FILE_SELECTED,
@@ -129,6 +143,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -157,6 +173,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -291,6 +309,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: false,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -314,6 +334,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -412,6 +434,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -438,6 +462,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -645,6 +671,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -670,6 +698,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: true,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -716,6 +746,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -761,6 +793,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -807,6 +841,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: true,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -850,6 +886,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -880,6 +918,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: false,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -956,6 +996,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: true,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         /**
          * Instantiate initial instance to set previous
@@ -1014,6 +1056,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -1043,7 +1087,7 @@ class TextAdventureUploaderTest extends TestCase
         }
     }
 
-    public function testUploadIsPossibleReturnsTrueIf_AFileWasSelected_TheSelectedFileIsAnHtmlFile_TheSelectedFileDoesNotExceedTheMaximumFileSize_ThePostRequestIdMatchesThePreviousRequestId(): void
+    public function testUploadIsPossibleReturnsTrueIf_AFileWasSelected_TheSelectedFileIsAnHtmlFile_TheSelectedFileDoesNotExceedTheMaximumFileSize_ThePostRequestIdMatchesThePreviousRequestId_And__FILES_ERRORS_IsSet(): void
     {
         $request = $this->mockRequest();
         $testFileName = $request->getUniqueId() . '.html';
@@ -1054,6 +1098,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -1148,6 +1194,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: false,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         if(!$textAdventureUploader->fileToUploadIsAnHtmlFile()) {
             $this->assertTrue(
@@ -1200,6 +1248,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         if($textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize()) {
             $this->assertTrue(
@@ -1279,6 +1329,8 @@ class TextAdventureUploaderTest extends TestCase
             fileIsAnHtmlFile: true,
             setReplaceExistingGame: false,
             setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -1317,6 +1369,43 @@ class TextAdventureUploaderTest extends TestCase
         }
         unlink($pathToTestFile);
         rmdir($textAdventureUploader->pathToUploadsDirectory());
+    }
+
+    public function testUploadIsPossibleReturnsFalseIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsNotSet(): void
+    {
+        $request =$this->mockRequest();
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: false,
+            setPostRequestId: true,
+            setFilesErrors: false,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+        );
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        if(
+            !isset($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error'])
+        ) {
+            $this->assertFalse(
+                $textAdventureUploader->uploadIsPossible(),
+                TextAdventureUploader::class .
+                '->uploadIsPossible() must ' .
+                'return false if $_FILES["' .
+                TextAdventureUploader::FILE_TO_UPLOAD_INDEX .
+                '"]["errors"] is not set.'
+            );
+        }
+        /**
+        if(
+        ) {
+            throw new RuntimeException('Bad Upload Request');
+        }
+         */
     }
 }
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -65,12 +65,12 @@ class TextAdventureUploaderTest extends TestCase
         if($fileWasSelected && $setFilesErrors && !$filesErrorsIsAnArray) {
             $_FILES
                 [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
-                ['error'] = $filesErrorsValue;
+                [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX] = $filesErrorsValue;
         }
         if($fileWasSelected && $filesErrorsIsAnArray) {
             $_FILES
                 [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
-                ['error'] = [$filesErrorsValue];
+                [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX] = [$filesErrorsValue];
         }
         $_FILES
             [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
@@ -1416,7 +1416,11 @@ class TextAdventureUploaderTest extends TestCase
             $this->mockComponentCrud()
         );
         if(
-            !isset($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error'])
+            !isset(
+                $_FILES
+                [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+                [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]
+            )
         ) {
             $this->assertFalse(
                 $textAdventureUploader->uploadIsPossible(),
@@ -1435,7 +1439,7 @@ class TextAdventureUploaderTest extends TestCase
          */
     }
 
-    //is_array($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error'])
+    //is_array($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX][TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX])
     /**
      * Checking the errors in the FILES array is recommended by the
      * following post on php.net:
@@ -1461,7 +1465,11 @@ class TextAdventureUploaderTest extends TestCase
             $this->mockComponentCrud()
         );
         if(
-            is_array($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error'])
+            is_array(
+                $_FILES
+                [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+                [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]
+            )
         ) {
             $this->assertFalse(
                 $textAdventureUploader->uploadIsPossible(),
@@ -1469,15 +1477,24 @@ class TextAdventureUploaderTest extends TestCase
                 '->uploadIsPossible() must ' .
                 'return false if $_FILES["' .
                 TextAdventureUploader::FILE_TO_UPLOAD_INDEX .
-                '"]["errors"] is an array.'
+                '"]["' .
+                TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX .
+                '"] is an array.'
             );
         }
-        /**
-        if(
-        ) {
-            throw new RuntimeException('Bad Upload Request');
-        }
-         */
+    }
+
+    public function test_FILE_UPLOAD_ERRORS_INDEX_IsAssignedTheString_error(): void
+    {
+        $expectedString = 'error';
+        $this->assertEquals(
+            $expectedString,
+            TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX,
+            TextAdventureUploader::class .
+            '::FILE_UPLOAD_ERRORS_INDEX ' .
+            'must be assigned the string: ' .
+            $expectedString
+        );
     }
 }
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -1036,6 +1036,19 @@ class TextAdventureUploaderTest extends TestCase
         );
     }
 
+    public function test_FILE_TO_UPLOAD_SIZE_EXCEEDS_ALLOWED_FILE_SIZE_ERROR_MESSAGE_IsAssignedTheAppropriateErrorMessage(): void
+    {
+        $expectedErrorMessage = 'The selected file is too large! ' .
+            'Please choose a file that is less than 5 megabytes.';
+        $this->assertEquals(
+            $expectedErrorMessage,
+            TextAdventureUploader::FILE_TO_UPLOAD_SIZE_EXCEEDS_ALLOWED_FILE_SIZE_ERROR_MESSAGE,
+            TextAdventureUploader::class .
+            '::FILE_TO_UPLOAD_SIZE_EXCEEDS_ALLOWED_FILE_SIZE_ERROR_MESSAGE ' .
+            'must be assigned the string: ' .
+            $expectedErrorMessage
+        );
+    }
     public function testRootUrlReturnsRootUrlDerivedFromSpecifiedRequest(): void
     {
         $request = $this->mockCurrentRequest();
@@ -1060,15 +1073,8 @@ class TextAdventureUploaderTest extends TestCase
 
 /**
  *
-$invalidFileTypeMessage = '
-    <p class="roady-error-message">
-        Only Twine html files can be uploaded!
-        Please select a Twine html file to upload
-    </p>
-';
 $fileIsToLargeMessage = '
     <p class="roady-error-message">
-        The file is too large!
     </p>
 ';
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -108,7 +108,7 @@ class TextAdventureUploaderTest extends TestCase
             );
     }
 
-    public function testNameOfFileToUploadRetunrsTheValueOfTheNO_FILE_SELECTEDConstantIfAFileHasNotBeenSelectedForUpload(): void
+    public function testNameOfFileToUploadReturnsTheValueOfTheNO_FILE_SELECTEDConstantIfAFileHasNotBeenSelectedForUpload(): void
     {
         $request = $this->mockRequest();
         $textAdventureUploader = new TextAdventureUploader(
@@ -140,7 +140,7 @@ class TextAdventureUploaderTest extends TestCase
         );
     }
 
-    public function testNameOfFileToUploadRetunrsTheNameOfTheFileToUploadIfAFileHasBeenSelectedForUpload(): void
+    public function testNameOfFileToUploadReturnsTheNameOfTheFileToUploadIfAFileHasBeenSelectedForUpload(): void
     {
         $request = $this->mockRequest();
         $this->mockUploadRequest(
@@ -151,7 +151,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -182,7 +182,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -319,7 +319,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -345,7 +345,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -446,7 +446,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -475,7 +475,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -685,7 +685,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -713,7 +713,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: true,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -762,7 +762,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -810,7 +810,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -847,6 +847,14 @@ class TextAdventureUploaderTest extends TestCase
         rmdir($textAdventureUploader->pathToUploadsDirectory());
     }
 
+    private function expectedPathToTestFile(TextAdventureUploader $textAdventureUploader, string $testFileName): string
+    {
+        return
+            $textAdventureUploader->pathToUploadsDirectory() .
+            DIRECTORY_SEPARATOR .
+            $testFileName;
+    }
+
     public function testUploadIsPossibleReturnsTrueIfAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUploadAndReplaceExistingGameReturnsTrue(): void
     {
         $request = $this->mockRequest();
@@ -859,7 +867,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: true,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -905,7 +913,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -938,7 +946,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -1017,7 +1025,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: true,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         /**
@@ -1078,7 +1086,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -1121,7 +1129,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -1218,7 +1226,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         if(!$textAdventureUploader->fileToUploadIsAnHtmlFile()) {
@@ -1273,7 +1281,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         if($textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize()) {
@@ -1355,7 +1363,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: true,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -1408,7 +1416,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: false,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -1431,15 +1439,8 @@ class TextAdventureUploaderTest extends TestCase
                 '"]["errors"] is not set.'
             );
         }
-        /**
-        if(
-        ) {
-            throw new RuntimeException('Bad Upload Request');
-        }
-         */
     }
 
-    //is_array($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX][TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX])
     /**
      * Checking the errors in the FILES array is recommended by the
      * following post on php.net:
@@ -1457,7 +1458,7 @@ class TextAdventureUploaderTest extends TestCase
             setReplaceExistingGame: false,
             setPostRequestId: true,
             setFilesErrors: false,
-            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsValue: UPLOAD_ERR_OK,
             filesErrorsIsAnArray: true,
         );
         $textAdventureUploader = new TextAdventureUploader(
@@ -1495,6 +1496,42 @@ class TextAdventureUploaderTest extends TestCase
             'must be assigned the string: ' .
             $expectedString
         );
+    }
+
+    public function testUploadIsPossibleReturnsFalseIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsNotSetTo_UPLOAD_ERR_OK(): void
+    {
+        $request =$this->mockRequest();
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: false,
+            setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
+        );
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        if(
+            $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]
+            !==
+            UPLOAD_ERR_OK
+        ) {
+            $this->assertFalse(
+                $textAdventureUploader->uploadIsPossible(),
+                TextAdventureUploader::class .
+                '->uploadIsPossible() must ' .
+                'return false if $_FILES["' .
+                TextAdventureUploader::FILE_TO_UPLOAD_INDEX .
+                '"]["errors"] is not set to UPLOAD_ERR_OK.'
+            );
+        }
     }
 }
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -1125,9 +1125,18 @@ class TextAdventureUploaderTest extends TestCase
 
     public function testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingATheSlectedFileIsNotAnHtmlFileIfFileToUploadIsAnHtmlFileReturnsFalse(): void
     {
+        $request = $this->mockRequest();
         $textAdventureUploader = new TextAdventureUploader(
-            $this->mockRequest(),
+            $request,
             $this->mockComponentCrud()
+        );
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: false,
+            setReplaceExistingGame: false,
+            setPostRequestId: true,
         );
         if(!$textAdventureUploader->fileToUploadIsAnHtmlFile()) {
             $this->assertTrue(
@@ -1165,6 +1174,39 @@ class TextAdventureUploaderTest extends TestCase
             $expectedErrorMessage
         );
     }
+
+    public function testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingATheSlectedFilesSizeExceedsTheMaximumAllowedFileSizeIfFileToUploadSizeExceedsAllowedFileSizeReturnsTrue(): void
+    {
+        $request = $this->mockRequest();
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: false,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: false,
+            setPostRequestId: true,
+        );
+        if($textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize()) {
+            $this->assertTrue(
+                in_array(
+                    TextAdventureUploader::FILE_TO_UPLOAD_SIZE_EXCEEDS_ALLOWED_FILE_SIZE_ERROR_MESSAGE,
+                    $textAdventureUploader->errorMessages(),
+                ),
+                TextAdventureUploader::class .
+                '->errorMessages() must return an array that ' .
+                'includes an error message that indicates a ' .
+                'the selected file\'s size eceeds the ' .
+                'maximum allowed files size if ' .
+                TextAdventureUploader::class .
+                '->fileToUploadIsAnHtmlFile() returns `false`'
+            );
+        }
+    }
+
     public function testRootUrlReturnsRootUrlDerivedFromSpecifiedRequest(): void
     {
         $request = $this->mockRequest();

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -45,6 +45,7 @@ class TextAdventureUploaderTest extends TestCase
         bool $setPostRequestId,
         bool $setFilesErrors,
         int $filesErrorsValue,
+        bool $filesErrorsIsAnArray,
     ): void
     {
         $request->import(
@@ -61,10 +62,15 @@ class TextAdventureUploaderTest extends TestCase
                 ]
             ]
         );
-        if($fileWasSelected && $setFilesErrors) {
+        if($fileWasSelected && $setFilesErrors && !$filesErrorsIsAnArray) {
             $_FILES
                 [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
                 ['error'] = $filesErrorsValue;
+        }
+        if($fileWasSelected && $filesErrorsIsAnArray) {
+            $_FILES
+                [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+                ['error'] = [$filesErrorsValue];
         }
         $_FILES
             [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
@@ -126,6 +132,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: false,
             setFilesErrors: false,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $this->assertEquals(
              TextAdventureUploader::NO_FILE_SELECTED,
@@ -145,6 +152,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -175,6 +183,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -311,6 +320,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -336,6 +346,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -436,6 +447,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -464,6 +476,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -673,6 +686,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -700,6 +714,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -748,6 +763,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -795,6 +811,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -843,6 +860,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -888,6 +906,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -920,6 +939,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -998,6 +1018,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         /**
          * Instantiate initial instance to set previous
@@ -1058,6 +1079,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -1100,6 +1122,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -1196,6 +1219,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         if(!$textAdventureUploader->fileToUploadIsAnHtmlFile()) {
             $this->assertTrue(
@@ -1250,6 +1274,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         if($textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize()) {
             $this->assertTrue(
@@ -1331,6 +1356,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: true,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -1383,6 +1409,7 @@ class TextAdventureUploaderTest extends TestCase
             setPostRequestId: true,
             setFilesErrors: false,
             filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -1398,6 +1425,51 @@ class TextAdventureUploaderTest extends TestCase
                 'return false if $_FILES["' .
                 TextAdventureUploader::FILE_TO_UPLOAD_INDEX .
                 '"]["errors"] is not set.'
+            );
+        }
+        /**
+        if(
+        ) {
+            throw new RuntimeException('Bad Upload Request');
+        }
+         */
+    }
+
+    //is_array($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error'])
+    /**
+     * Checking the errors in the FILES array is recommended by the
+     * following post on php.net:
+     *
+     * @see https://www.php.net/manual/en/features.file-upload.php
+     */
+    public function testUploadIsPossibleReturnsFalseIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsAnArray(): void
+    {
+        $request =$this->mockRequest();
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: false,
+            setPostRequestId: true,
+            setFilesErrors: false,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: true,
+        );
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        if(
+            is_array($_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error'])
+        ) {
+            $this->assertFalse(
+                $textAdventureUploader->uploadIsPossible(),
+                TextAdventureUploader::class .
+                '->uploadIsPossible() must ' .
+                'return false if $_FILES["' .
+                TextAdventureUploader::FILE_TO_UPLOAD_INDEX .
+                '"]["errors"] is an array.'
             );
         }
         /**

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -1060,7 +1060,7 @@ class TextAdventureUploaderTest extends TestCase
         }
     }
 
-    public function testAFileWasSelectedReturnsFalseIfAFileWasNotSeletedForUpload(): void
+    public function testAFileWasSelectedForUploadReturnsFalseIfAFileWasNotSeletedForUpload(): void
     {
         $request = $this->mockRequest();
         $textAdventureUploader = new TextAdventureUploader(
@@ -1072,6 +1072,39 @@ class TextAdventureUploaderTest extends TestCase
             TextAdventureUploader::class .
             '->aFileWasSelectedForUpload() must return `false` if ' .
             'a file was not selected for upload.'
+        );
+        /**
+         * Also test case where
+         * $_FILES
+         * [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+         * [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]
+         * === UPLOAD_ERR_NO_FILE
+         */
+        $request = $this->mockRequest();
+        $this->mockUploadRequest(
+            $request,
+            // Set fileWasSelected to true,
+            // UPLOAD_ERR_NO_FILE is what is being tested here.
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: false,
+            setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_NO_FILE,
+            filesErrorsIsAnArray: false,
+        );
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $this->assertFalse(
+            $textAdventureUploader->aFileWasSelectedForUpload(),
+            TextAdventureUploader::class .
+            '->aFileWasSelectedForUpload() must return `false` if ' .
+            '$_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]' .
+            '[TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX] ' .
+            'is set to UPLOAD_ERR_NO_FILE'
         );
     }
 

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -814,12 +814,17 @@ class TextAdventureUploaderTest extends TestCase
 
     public function testUploadIsPossibleReturnsFalseIfFileToUploadSizeExceedsAllowedFileSizeReturnsTrue(): void
     {
-        $_FILES
-            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
-            [TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX]
-            = self::INVALID_FILE_SIZE;
+        $request =$this->mockRequest();
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: false,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: true,
+            setPostRequestId: true,
+        );
         $textAdventureUploader = new TextAdventureUploader(
-            $this->mockRequest(),
+            $request,
             $this->mockComponentCrud()
         );
         if(
@@ -839,12 +844,15 @@ class TextAdventureUploaderTest extends TestCase
 
     public function testUploadIsPossibleReturnsFalseIfFileToUploadIsAnHtmlFileReturnsFalse(): void
     {
-
         $request = $this->mockRequest();
-        $_FILES
-            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
-            [TextAdventureUploader::FILENAME_INDEX]
-            = $request->getUniqueId();
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: false,
+            setReplaceExistingGame: true,
+            setPostRequestId: true,
+        );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
             $this->mockComponentCrud()
@@ -913,26 +921,19 @@ class TextAdventureUploaderTest extends TestCase
     public function testUploadIsPossibleReturnsFalseIfPostRequestIdDoesNotMatchPreviousRequestId(): void
     {
         $request = $this->mockRequest();
-        $testFileName = $request->getUniqueId() . '.html';
-        $_FILES
-            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
-            [TextAdventureUploader::FILENAME_INDEX]
-            = $testFileName;
-        $request->import(
-            [
-                'post' => [
-                    TextAdventureUploader::REPLACE_EXISTING_GAME_INDEX
-                    => 'true',
-                    TextAdventureUploader::POST_REQUEST_ID_INDEX
-                    => $request->getUniqueId()
-                ]
-            ]
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: true,
+            setPostRequestId: true,
         );
         /**
          * Instantiate initial instance to set previous
          * Request.
          */
-        $textAdventureUploader = new TextAdventureUploader(
+        $intialTextAdventureUploader = new TextAdventureUploader(
             $request,
             $this->mockComponentCrud()
         );
@@ -978,18 +979,13 @@ class TextAdventureUploaderTest extends TestCase
     public function testAFileWasSelectedReturnsTrueIfAFileWasSeletedForUpload(): void
     {
         $request = $this->mockRequest();
-        $testFileName = $request->getUniqueId() . '.html';
-        $_FILES
-            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
-            [TextAdventureUploader::FILENAME_INDEX]
-            = $testFileName;
-        $request->import(
-            [
-                'post' => [
-                    TextAdventureUploader::POST_REQUEST_ID_INDEX
-                    => $request->getUniqueId()
-                ]
-            ]
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: true,
+            setPostRequestId: true,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,
@@ -1023,21 +1019,13 @@ class TextAdventureUploaderTest extends TestCase
     {
         $request = $this->mockRequest();
         $testFileName = $request->getUniqueId() . '.html';
-        $_FILES
-            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
-            [TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX]
-            = self::MAXIMUM_ALLOWED_FILE_SIZE;
-        $_FILES
-            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
-            [TextAdventureUploader::FILENAME_INDEX]
-            = $testFileName;
-        $request->import(
-            [
-                'post' => [
-                    TextAdventureUploader::POST_REQUEST_ID_INDEX
-                    => $request->getUniqueId()
-                ]
-            ]
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: true,
+            setPostRequestId: true,
         );
         $textAdventureUploader = new TextAdventureUploader(
             $request,


### PR DESCRIPTION
commit d03b7545ca11b612f4c65c9420c77f181a7db683
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Mon May 23 12:40:52 2022 -0400

    Working on TextAdventureImporter.
    
    Made the following changes in
    `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`
    
    - Renamed `testAFileWasSelectedReturnsFalseIfAFileWasNotSeletedForUpload()`
      to `testAFileWasSelectedForUploadReturnsFalseIfAFileWasNotSeletedForUpload()`
    - Refactored `testAFileWasSelectedForUploadReturnsFalseIfAFileWasNotSeletedForUpload()`
      to test that `TextAdventureUploader->aFileWasSelectedForUpload()`
      returns false if
      `$_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX][TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]`
      is set to `UPLOAD_ERR_NO_FILE`.
    
    Made the following changes in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`:
    
    - Refactored `aFileWasSelectedForUpload()` to return false if
      `$_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX][TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]`
      is set to `UPLOAD_ERR_NO_FILE`.

commit db0373f33b672c74d56c13a1495b89479626c643
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Mon May 23 00:46:45 2022 -0400

    Working on TextAdventureImporter.
    
    Cleaned up code in the following files:
    
    - TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
    - TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php

commit 5da2d938c3e7633817e79f22243541d8e2a438b6
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 22 15:43:47 2022 -0400

    Working on TextAdventureImporter.
    
    Made the following changes in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:
    
    - Implemented new test method `testUploadIsPossibleReturnsFalseIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsNotSetTo_UPLOAD_ERR_OK()`.
    - Code clean up.
    
    Refactored `uploadIsPossible()` to return false
    `$_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX][TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]`
    is not equal to `UPLOAD_ERR_OK` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`

commit fd89e65a8d2f7012de70339872439bdf1083cf7c
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 22 01:18:39 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented new test method
    `test_FILE_UPLOAD_ERRORS_INDEX_IsAssignedTheString_error()`
    in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
    Defined new constant `FILE_UPLOAD_ERRORS_INDEX` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.
    
    Cleaned up code in `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`

commit 0aebd0b30f1aa6d51656eb9e7f0e84cb60bdd58b
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 22 00:49:29 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented new test method `testUploadIsPossibleReturnsFalseIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsAnArray()`
    in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
    Refactored `uploadIsPossible()` in `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    to return false if `$_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error']`
    is an array.

commit 704eb16892537e2f57e7bfd6132477c4a99b977e
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sat May 21 12:05:18 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented the following changes in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:
    
    - Implemented new test method `testUploadIsPossibleReturnsFalseIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsNotSet()`
    - Renamed `testUploadIsPossibleReturnsTrueIf_AFileWasSelected_TheSelectedFileIsAnHtmlFile_TheSelectedFileDoesNotExceedTheMaximumFileSize_ThePostRequestIdMatchesThePreviousRequestId()` to `testUploadIsPossibleReturnsTrueIf_AFileWasSelected_TheSelectedFileIsAnHtmlFile_TheSelectedFileDoesNotExceedTheMaximumFileSize_ThePostRequestIdMatchesThePreviousRequestId_And__FILES_ERRORS_IsSet()`
    - Refactored mockUploadRequest() to set
      $_FILES['fileToUpload']['errors]' when appropriate.
    
    Made the following changes in `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`:
    
    - Refactored 'uploadIsPossible()' to return false if `$_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error']` is no set.
    
    Mocked check to make sure
    `$_FILES[TextAdventureUploader::FILE_TO_UPLOAD_INDEX]['error']`
    is not an array in
    `TextAdventureImporter/DynamicOutput/TextAdventureImporter.php`

commit 2410d4294e83876ea571921a88cf81bcff174cc2
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Fri May 20 14:40:55 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented new test method
    `testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingThatAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUpload_IfAFileAlreadyExistsWhoseNameMatchesTheNameOfTheFileSelectedToUploadAndReplaceExistingGameReturnsFalse()`
    in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
    Refactored `replaceExistingGame()` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    to add the
    TextAdventureUploader::FILE_WAS_ALREADY_UPLOADED_AND_REQUEST_DID_NOT_INDICATE_EXISTING_FILE_SHOULD_BE_REPLACE_ERROR_MESSAGE
    to the error messages array if `replaceExistingGame()` returns false.

commit 16bb56dfe71825c4a8f619754774ba5dc2c6b1b6
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Fri May 20 12:51:44 2022 -0400

    Working on TextAdventureImporter.
    
    Made the following changes in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:
    
    - Implemented new test method `test_FILE_WAS_ALREADY_UPLOADED_AND_REQUEST_DID_NOT_INDICATE_EXISTING_FILE_SHOULD_BE_REPLACE_ERROR_MESSAGE_IsAssignedTheAppropriateErrorMessage()`.
    - Renamed `testReplaceExistingGameReturnsTrueIfValueSetInSpecifiedRequestsPOSTDataForReplaceExistingGameIsSetToTheString_true()` to `testReplaceExistingGameReturnsTrueIf_POST_REPLACE_EXISTING_GAME_INDEX_IsSetToTheString_true()`.
    - `testReplaceExistingGameReturnsTrueIf_POST_REPLACE_EXISTING_GAME_INDEX_IsSetToTheString_true()` now appropriately mocks an upload Request.
    - Renamed
      `testReplaceExistingGameReturnsFalseIfValueSetInSpecifiedRequestsPOSTDataForReplaceExistingGameIsNotSetToTheString_true()` to `testReplaceExistingGameReturnsFalseIf_POST_REPLACE_EXISTING_GAME_INDEX_IsNotSetToTheString_true()`.
    - `testReplaceExistingGameReturnsFalseIf_POST_REPLACE_EXISTING_GAME_INDEX_IsNotSetToTheString_true()` now appropriately mocks an upload Request.
    
    Defined new constant `FILE_WAS_ALREADY_UPLOADED_AND_REQUEST_DID_NOT_INDICATE_EXISTING_FILE_SHOULD_BE_REPLACE_ERROR_MESSAGE`
    in `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.

commit 38f5c3c2cd6a073e29f33c13da24a198973c90d8
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Fri May 20 02:33:51 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented new test method
    `testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingATheSlectedFilesSizeExceedsTheMaximumAllowedFileSizeIfFileToUploadSizeExceedsAllowedFileSizeReturnsTrue()`
    in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
    Refactored `fileToUploadSizeExceedsAllowedFileSize()` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`
    to add an appropriate error message to the error messages array if
    the selected file's size exceeds the
    TextAdventureUploader::MAXIMUM_ALLOWED_FILE_SIZE.

commit d66a4cfea5212cacc786ba36efef77e083962f23
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Thu May 19 01:35:42 2022 -0400

    Working on TextAdventureImporter.
    
    Code clean up in the following files;
    
    - TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
    - TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php

commit 4bd0e5d7714d84da7aabd3eb21c1eadfdc641304
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Tue May 17 17:43:18 2022 -0400

    Working on TextAdventureImporter.
    
    Code clean up in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.

commit 12bf1d9d50b8c72722d06578da7d5fb12eb90480
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Tue May 17 17:20:11 2022 -0400

    Working on TextAdventureImporter.
    
    Code clean up in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`

commit 00e413610ab3807e2dadb2e52489c918611bb724
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Tue May 17 14:06:57 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented the following new test method in
    `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:
    
    - `test_MAXIMUM_ALLOWED_FILE_SIZE_IsAssignedTheInteger_1000000()`
    
    Renamed the following test methods in
    `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:
    
    - `testFileToUploadSizeExceedsAllowedFileSizeReturnsTrueIfSizeOfFileToUploadExceedsAllowedFileSize()`
    - `testFileToUploadSizeExceedsAllowedFileSizeReturnsFalseIfSizeOfFileToUploadDoesNotExceedAllowedFileSize()`
    
    Code clean up in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
    Defined new constant `MAXIMUM_ALLOWED_FILE_SIZE` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.

commit 5e26567dd26bbd39b3ec3c2cbe9e610cfa341de5
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Fri May 13 11:50:29 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented new test method
    `test_FILE_TO_UPLOAD_SIZE_EXCEEDS_ALLOWED_FILE_SIZE_ERROR_MESSAGE_IsAssignedTheAppropriateErrorMessage()`
    in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
    Defined new constant `FILE_TO_UPLOAD_SIZE_EXCEEDS_ALLOWED_FILE_SIZE_ERROR_MESSAGE` in
    `TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php`.