### PR TITLE
Working on TextAdventureImporter

### DIFF
--- a/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
+++ b/TextAdventureImporter/resources/classes/utility/TextAdventureUploader.php
@@ -165,6 +165,14 @@ class TextAdventureUploader {
         if (
             (
                 $_FILES
+                [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+                [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]
+                ===
+                UPLOAD_ERR_INI_SIZE
+            )
+            ||
+            (
+                $_FILES
                 [self::FILE_TO_UPLOAD_INDEX]
                 [TextAdventureUploader::FILE_TO_UPLOAD_SIZE_INDEX]
                 ??

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -10,6 +10,86 @@ use roady\classes\component\Web\Routing\Request;
 use roady\classes\primary\Storable;
 use roady\classes\primary\Switchable;
 
+/**
+ * TextAdventureUploaderTest. Defines test methods for the
+ * `Apps\TextAdventureImporter\resources\classes\utility\TextAdventureUploader`;
+ *
+ * Methods:
+ *
+ * private function expectedMaximumFileSize(): int
+ * private function expectedPathToTestFile(TextAdventureUploader $textAdventureUploader, string $testFileName): string
+ * private function invalidFileSize(): int
+ * private function mockRequest(): Request
+ * private function mockUploadRequest(
+ *     Request $request,
+ *     bool $fileWasSelected,
+ *     bool $fileSizeIsValid,
+ *     bool $fileIsAnHtmlFile,
+ *     bool $setReplaceExistingGame,
+ *     bool $setPostRequestId,
+ *     bool $setFilesErrors,
+ *     int $filesErrorsValue,
+ *     bool $filesErrorsIsAnArray,
+ * ): void
+ * public function mockComponentCrud(): ComponentCrud
+ * public function tearDown(): void
+ * public function tesTEMPORARY_FILENAME_INDEXConstantIsAssignedTheString__tmp_name(): void
+ * public function testAFileWasSelectedForUploadReturnsFalseIfAFileWasNotSeletedForUpload(): void
+ * public function testAFileWasSelectedReturnsTrueIfAFileWasSeletedForUpload(): void
+ * public function testComponentCrudReturnsAssignedComponentCrud(): void
+ * public function testCurrentRequestReturnsARequestInstanceWhoseGetDataMatchesTheCurrentRequestsGetData(): void
+ * public function testCurrentRequestReturnsARequestInstanceWhosePostDataMatchesTheCurrentRequestsPostData(): void
+ * public function testCurrentRequestReturnsARequestInstanceWhoseUrlMatchesTheRequestSpecifiedOnInstantiation(): void
+ * public function testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingAFileWasNotSelectedForUploadIfAFileWasSelectedForUploadReturnsFalse(): void
+ * public function testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingATheSlectedFileIsNotAnHtmlFileIfFileToUploadIsAnHtmlFileReturnsFalse(): void
+ * public function testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingATheSlectedFilesSizeExceedsTheMaximumAllowedFileSizeIfFileToUploadSizeExceedsAllowedFileSizeReturnsTrue(): void
+ * public function testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingThatAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUpload_IfAFileAlreadyExistsWhoseNameMatchesTheNameOfTheFileSelectedToUploadAndReplaceExistingGameReturnsFalse(): void
+ * public function testFILENAME_INDEXConstantIsAssignedTheString_name(): void
+ * public function testFILE_TO_UPLOAD_INDEXConstantIsAssignedTheString_fileToUpload(): void
+ * public function testFILE_TO_UPLOAD_SIZE_INDEXConstantIsAssignedTheString_size(): void
+ * public function testFileToUploadIsAnHtmlFileReturnsFalseIfFileSelcetedForUploadDoesNotHaveTheExtension_html(): void
+ * public function testFileToUploadIsAnHtmlFileReturnsTrueIfFileSelcetedForUploadHasTheExtension_html(): void
+ * public function testFileToUploadSizeExceedsAllowedFileSizeReturnsFalseIfSizeOfFileToUploadDoesNotExceedAllowedFileSize(): void
+ * public function testFileToUploadSizeExceedsAllowedFileSizeReturnsTrueIfSizeOfFileToUploadExceedsAllowedFileSize(): void
+ * public function testFileToUploadsTemporaryNameReturnsTheString_NO_FILE_SELECTED_If_FILES__FILE_TO_UPLOAD_INDEX__TEMPORARY_FILENAME_INDEX_IsNotSet(): void
+ * public function testFileToUploadsTemporaryNameReturnsValueAssignedTo_FILES__FILE_TO_UPLOAD_INDEX__TEMPORARY_FILENAME_INDEX_IfItIsSet(): void
+ * public function testMaximumAllowedFileSizeReturnsTheValueOfTHeIniSetting_upload_max_filesize_ConvertedIntpBytes(): void
+ * public function testNO_FILE_SELECTEDConstantIsAssignedTheString_NO_FILE_SELECTED(): void
+ * public function testNameOfFileToUploadReturnsTheNameOfTheFileToUploadIfAFileHasBeenSelectedForUpload(): void
+ * public function testNameOfFileToUploadReturnsTheValueOfTheNO_FILE_SELECTEDConstantIfAFileHasNotBeenSelectedForUpload(): void
+ * public function testPOST_REQUEST_ID_INDEXConstantIsAssignedTheString_postRequestId(): void
+ * public function testPathToUploadFileToReturnsTheNameOfFileToUploadPrefixedByThePathToUploadsDirectory(): void
+ * public function testPathToUploadFileToReturnsTheString_NO_FILE_SELECTED_IfAFileHasNotBeenSelectedForUpload(): void
+ * public function testPathToUploadsDirectoryReturnsExpectedPathToUploadsDirectory(): void
+ * public function testPostRequestIdReturnsThePostRequestIdSetInTheCurrentRequestsPOSTData(): void
+ * public function testPostRequestIdReturnsTheString_NO_FILE_SELECTED_IfPostRequestIdIsNotSetInCurrentRequestsPOSTData(): void
+ * public function testPreviousRequestReturnsPreviouslyStoredRequest(): void
+ * public function testPreviousRequestReturnsSpecifiedRequestIfARequestWasNotPreviouslyStored(): void
+ * public function testREPLACE_EXISTING_GAME_INDEXConstantIsAssignedTheString_replaceExistingGame(): void
+ * public function testReplaceExistingGameReturnsFalseIf_POST_REPLACE_EXISTING_GAME_INDEX_IsNotSetToTheString_true(): void
+ * public function testReplaceExistingGameReturnsTrueIf_POST_REPLACE_EXISTING_GAME_INDEX_IsSetToTheString_true(): void
+ * public function testRootUrlReturnsRootUrlDerivedFromSpecifiedRequest(): void
+ * public function testSpecifiedRequestIsStoredOnInstantiation(): void
+ * public function testSpecifiedRequestReplacesExistingStoredRequestWhoseNameTypeLocationAndContainerMatchSpecifiedRequestOnInstantiation(): void
+ * public function testUploadCreatesUploadsDirectoryIfItDoesNotExist(): void
+ * public function testUploadIsPossibleReturnsFalseIfAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUploadAndReplaceExistingGameReturnsFalse(): void
+ * public function testUploadIsPossibleReturnsFalseIfAFileWasSelectedReturnsFalse(): void
+ * public function testUploadIsPossibleReturnsFalseIfCurrentRequestsPostRequestIdDoesNotMatchPreviousRequestPostRequestId(): void
+ * public function testUploadIsPossibleReturnsFalseIfDoesNotMatchPostRequestIdIsNotSet(): void
+ * public function testUploadIsPossibleReturnsFalseIfFileToUploadIsAnHtmlFileReturnsFalse(): void
+ * public function testUploadIsPossibleReturnsFalseIfFileToUploadSizeExceedsAllowedFileSizeReturnsTrue(): void
+ * public function testUploadIsPossibleReturnsFalseIfNameOfFileToUploadReturnsTheString_NO_FILE_SELECTED(): void
+ * public function testUploadIsPossibleReturnsFalseIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsAnArray(): void
+ * public function testUploadIsPossibleReturnsFalseIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsNotSet(): void
+ * public function testUploadIsPossibleReturnsFalseIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsNotSetTo_UPLOAD_ERR_OK(): void
+ * public function testUploadIsPossibleReturnsTrueIfAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUploadAndReplaceExistingGameReturnsTrue(): void
+ * public function testUploadIsPossibleReturnsTrueIf_AFileWasSelected_TheSelectedFileIsAnHtmlFile_TheSelectedFileDoesNotExceedTheMaximumFileSize_ThePostRequestIdMatchesThePreviousRequestId_And__FILES_ERRORS_IsSet(): void
+ * public function test_A_FILE_WAS_NOT_SELECTED_FOR_UPLOAD_ERROR_MESSAGE_IsAssignedTheAppropriateErrorMessage(): void
+ * public function test_FILE_UPLOAD_ERRORS_INDEX_IsAssignedTheString_error(): void
+ * public function test_FILE_WAS_ALREADY_UPLOADED_AND_REQUEST_DID_NOT_INDICATE_EXISTING_FILE_SHOULD_BE_REPLACE_ERROR_MESSAGE_IsAssignedTheAppropriateErrorMessage(): void
+ * public function test_SELECTED_FILE_IS_NOT_AN_HTML_FILE_ERROR_MESSAGE_IsAssignedTheAppropriateErrorMessage(): void
+ * public function test_fileToUploadSizeExceedsAllowedFileSizeErrorMessage_ReturnsTheAppropriateErrorMessage(): void
+ */
 class TextAdventureUploaderTest extends TestCase
 {
 
@@ -1000,31 +1080,34 @@ class TextAdventureUploaderTest extends TestCase
         }
     }
 
-    public function testUploadIsPossibleReturnsFalseIfPreviousRequestIdDoesNotMatchPostRequestId(): void
+    public function testUploadIsPossibleReturnsFalseIfDoesNotMatchPostRequestIdIsNotSet(): void
     {
+        $request = $this->mockRequest();
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: true,
+            setPostRequestId: false,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_OK,
+            filesErrorsIsAnArray: false,
+        );
         $textAdventureUploader = new TextAdventureUploader(
-            $this->mockRequest(),
+            $request,
             $this->mockComponentCrud()
         );
-        if(
-            $textAdventureUploader->previousRequest()->getUniqueId()
-            !==
-            $textAdventureUploader->postRequestId()
-        ) {
-            $this->assertFalse(
-                $textAdventureUploader->uploadIsPossible(),
-                TextAdventureUploader::class .
-                '->uploadIsPossible() must return false ' .
-                'if the id returned by ' .
-                TextAdventureUploader::class .
-                '->postRequestId() does not match the ' .
-                'the previous ' . Request::class . '\'s ' .
-                'unique id.'
-            );
-        }
+        $this->assertFalse(
+            $textAdventureUploader->uploadIsPossible(),
+            TextAdventureUploader::class .
+            '->uploadIsPossible() must return false ' .
+            'if the postRequestId is not set in the current ' .
+            'upload Request.'
+        );
     }
 
-    public function testUploadIsPossibleReturnsFalseIfPostRequestIdDoesNotMatchPreviousRequestId(): void
+    public function testUploadIsPossibleReturnsFalseIfCurrentRequestsPostRequestIdDoesNotMatchPreviousRequestPostRequestId(): void
     {
         $request = $this->mockRequest();
         $this->mockUploadRequest(

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -1690,6 +1690,125 @@ class TextAdventureUploaderTest extends TestCase
             );
         }
     }
+
+
+    public function testFileToUploadSizeExceedsAllowedFileSizeReturnsTrueIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsSetTo_UPLOAD_ERR_INI_SIZE(): void
+    {
+        $request =$this->mockRequest();
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: false,
+            setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_INI_SIZE,
+            filesErrorsIsAnArray: false,
+        );
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        if(
+            $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]
+            ===
+            UPLOAD_ERR_INI_SIZE
+        ) {
+            $this->assertTrue(
+                $textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize(),
+                TextAdventureUploader::class .
+                '->fileToUploadSizeExceedsAllowedFileSize() must ' .
+                'return true if $_FILES["' .
+                TextAdventureUploader::FILE_TO_UPLOAD_INDEX .
+                '"]["errors"] is set to UPLOAD_ERR_INI_SIZE.'
+            );
+        }
+    }
+
+    public function testUploadIsPossibleReturnsFalseIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsSetTo_UPLOAD_ERR_INI_SIZE(): void
+    {
+        $request =$this->mockRequest();
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: false,
+            setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_INI_SIZE,
+            filesErrorsIsAnArray: false,
+        );
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        if(
+            $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]
+            ===
+            UPLOAD_ERR_INI_SIZE
+        ) {
+            $this->assertFalse(
+                $textAdventureUploader->uploadIsPossible(),
+                TextAdventureUploader::class .
+                '->uploadIsPossible() must ' .
+                'return false if $_FILES["' .
+                TextAdventureUploader::FILE_TO_UPLOAD_INDEX .
+                '"]["errors"] is not set to UPLOAD_ERR_OK.'
+            );
+        }
+    }
+
+    public function testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingATheSlectedFilesSizeExceedsTheMaximumAllowedFileSizeIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsSetTo_UPLOAD_ERR_INI_SIZE(): void
+    {
+        $request = $this->mockRequest();
+        $textAdventureUploader = new TextAdventureUploader(
+            $request,
+            $this->mockComponentCrud()
+        );
+        $this->mockUploadRequest(
+            $request,
+            fileWasSelected: true,
+            fileSizeIsValid: true,
+            fileIsAnHtmlFile: true,
+            setReplaceExistingGame: false,
+            setPostRequestId: true,
+            setFilesErrors: true,
+            filesErrorsValue: UPLOAD_ERR_INI_SIZE,
+            filesErrorsIsAnArray: false,
+        );
+        if(
+            $textAdventureUploader->fileToUploadSizeExceedsAllowedFileSize()
+            &&
+            $_FILES
+            [TextAdventureUploader::FILE_TO_UPLOAD_INDEX]
+            [TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX]
+            ===
+            UPLOAD_ERR_INI_SIZE
+        ) {
+            $this->assertTrue(
+                in_array(
+                    $textAdventureUploader->fileToUploadSieExceedsAllowedFileSizeErrorMessage(),
+                    $textAdventureUploader->errorMessages(),
+                ),
+                TextAdventureUploader::class .
+                '->errorMessages() must return an array that ' .
+                'includes an error message that indicates a ' .
+                'the selected file\'s size eceeds the ' .
+                'maximum allowed files size if ' .
+                '`$_FILES[' .
+                TextAdventureUploader::FILE_TO_UPLOAD_INDEX .
+                '][' .
+                TextAdventureUploader::FILE_UPLOAD_ERRORS_INDEX .
+                '] is set to `UPLOAD_ERR_INI_SIZE`'
+            );
+        }
+    }
 }
 
 /**

--- a/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
+++ b/TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php
@@ -72,10 +72,10 @@ use roady\classes\primary\Switchable;
  * public function testSpecifiedRequestIsStoredOnInstantiation(): void
  * public function testSpecifiedRequestReplacesExistingStoredRequestWhoseNameTypeLocationAndContainerMatchSpecifiedRequestOnInstantiation(): void
  * public function testUploadCreatesUploadsDirectoryIfItDoesNotExist(): void
- * public function testUploadIsPossibleReturnsFalseIfAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUploadAndReplaceExistingGameReturnsFalse(): void
+ * public function testUploadIsPossibleReturnsFalseIfReplaceExistingGameReturnsFalseAndAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUpload(): void
  * public function testUploadIsPossibleReturnsFalseIfAFileWasSelectedReturnsFalse(): void
- * public function testUploadIsPossibleReturnsFalseIfCurrentRequestsPostRequestIdDoesNotMatchPreviousRequestPostRequestId(): void
- * public function testUploadIsPossibleReturnsFalseIfDoesNotMatchPostRequestIdIsNotSet(): void
+ * public function testUploadIsPossibleReturnsFalseIfCurrentRequestsPostRequestIdDoesNotMatchPreviousRequestsUniqueId(): void
+ * public function testUploadIsPossibleReturnsFalseIfPostRequestIdIsNotSet(): void
  * public function testUploadIsPossibleReturnsFalseIfFileToUploadIsAnHtmlFileReturnsFalse(): void
  * public function testUploadIsPossibleReturnsFalseIfFileToUploadSizeExceedsAllowedFileSizeReturnsTrue(): void
  * public function testUploadIsPossibleReturnsFalseIfNameOfFileToUploadReturnsTheString_NO_FILE_SELECTED(): void
@@ -888,7 +888,7 @@ class TextAdventureUploaderTest extends TestCase
         rmdir($textAdventureUploader->pathToUploadsDirectory());
     }
 
-    public function testUploadIsPossibleReturnsFalseIfAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUploadAndReplaceExistingGameReturnsFalse(): void
+    public function testUploadIsPossibleReturnsFalseIfReplaceExistingGameReturnsFalseAndAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUpload(): void
     {
         $request = $this->mockRequest();
         $testFileName = $request->getUniqueId() . '.html';
@@ -1080,7 +1080,7 @@ class TextAdventureUploaderTest extends TestCase
         }
     }
 
-    public function testUploadIsPossibleReturnsFalseIfDoesNotMatchPostRequestIdIsNotSet(): void
+    public function testUploadIsPossibleReturnsFalseIfPostRequestIdIsNotSet(): void
     {
         $request = $this->mockRequest();
         $this->mockUploadRequest(
@@ -1107,7 +1107,7 @@ class TextAdventureUploaderTest extends TestCase
         );
     }
 
-    public function testUploadIsPossibleReturnsFalseIfCurrentRequestsPostRequestIdDoesNotMatchPreviousRequestPostRequestId(): void
+    public function testUploadIsPossibleReturnsFalseIfCurrentRequestsPostRequestIdDoesNotMatchPreviousRequestsUniqueId(): void
     {
         $request = $this->mockRequest();
         $this->mockUploadRequest(


### PR DESCRIPTION
commit 7a259103803b2d5a4a10fa46781be1e00c8be970
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 29 02:01:06 2022 -0400

    Working on TextAdventureImporter.
    
    Implemented the following new test methods in `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:
    
    - `testErrorsReturnsAnArrayThatIncludesAnErrorMessageIndicatingATheSlectedFilesSizeExceedsTheMaximumAllowedFileSizeIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsSetTo_UPLOAD_ERR_INI_SIZE()`
    - `testUploadIsPossibleReturnsFalseIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsSetTo_UPLOAD_ERR_INI_SIZE()`
    - `testFileToUploadSizeExceedsAllowedFileSizeReturnsTrueIf_FILES_FILE_TO_UPLOAD_INDEX_ERRORS_IsSetTo_UPLOAD_ERR_INI_SIZE()`

commit 92d855aab78f9f337622690bb7c9575bb4cab709
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sun May 29 00:24:00 2022 -0400

    Working on TextAdventureImporter.
    
    Refactored `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`.
    
    Renamed `testUploadIsPossibleReturnsFalseIfAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUploadAndReplaceExistingGameReturnsFalse()`
    `testUploadIsPossibleReturnsFalseIfReplaceExistingGameReturnsFalseAndAFileWasAlreadyUploadedWhoseNameMatchesTheNameOfTheFileToUpload()`.
    
    Renamed `testUploadIsPossibleReturnsFalseIfDoesNotMatchPostRequestIdIsNotSet() `
    `testUploadIsPossibleReturnsFalseIfPostRequestIdIsNotSet()`.
    
    Renamed `testUploadIsPossibleReturnsFalseIfCurrentRequestsPostRequestIdDoesNotMatchPreviousRequestPostRequestId()`
    `testUploadIsPossibleReturnsFalseIfCurrentRequestsPostRequestIdDoesNotMatchPreviousRequestsUniqueId()`.

commit 4e28f1fb1fc66a5af9f7c5c67156a547e02ec3c3
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Fri May 27 18:22:54 2022 -0400

    Working on TextAdventureImporter.
    
    Refactored `TextAdventureImporter/resources/tests/utility/TextAdventureUploaderTest.php`:
    
    - Renamed test method `testUploadIsPossibleReturnsFalseIfPostRequestIdDoesNotMatchPreviousRequestId()` to `testUploadIsPossibleReturnsFalseIfCurrentRequestsPostRequestIdDoesNotMatchPreviousRequestPostRequestId()`
    - Renamed test method `testUploadIsPossibleReturnsFalseIfPreviousRequestIdDoesNotMatchPostRequestId()` to `testUploadIsPossibleReturnsFalseIfDoesNotMatchPostRequestIdIsNotSet()`
    - Added doc comment with method listing.